### PR TITLE
Verbose error responses; 204 -> triggers json_error (nonsense)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 /vendor
 /coverage
 test.php
+/nbproject/

--- a/src/Exceptions/ChartMogulException.php
+++ b/src/Exceptions/ChartMogulException.php
@@ -41,7 +41,7 @@ class ChartMogulException extends \RuntimeException implements ResponseException
             $this->response = json_last_error() === JSON_ERROR_NONE? $json : $body;
             
             // Adding body to message to get the whole error message to API user.
-            $message = $message . " " . $body;
+            $message = $message . " Response:\n " . $body;
         }
 
         parent::__construct($message, $this->statusCode, $previous);

--- a/src/Exceptions/ChartMogulException.php
+++ b/src/Exceptions/ChartMogulException.php
@@ -23,6 +23,7 @@ class ChartMogulException extends \RuntimeException implements ResponseException
 
     /**
      * ChartMogulException
+     * You can match against subclasses or parsed response.
      * @param string $message Exception message
      * @param ResponseInterface|null $response  ResponseInterface object
      * @param \Exception|null $previous
@@ -38,6 +39,9 @@ class ChartMogulException extends \RuntimeException implements ResponseException
             $json = json_decode($body, true);
 
             $this->response = json_last_error() === JSON_ERROR_NONE? $json : $body;
+            
+            // Adding body to message to get the whole error message to API user.
+            $message = $message . " " . $body;
         }
 
         parent::__construct($message, $this->statusCode, $previous);

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -191,37 +191,33 @@ class Client implements ClientInterface
                     "JSON schema validation hasn't passed.",
                     $response
                 );
-                break;
             case 401:
             case 403:
                 throw new \ChartMogul\Exceptions\ForbiddenException(
                     "The requested action is forbidden.",
                     $response
                 );
-                break;
             case 404:
                 throw new \ChartMogul\Exceptions\NotFoundException(
-                    "The requested ".$this->resourceKey." could not be found.",
+                    "The resource could not be found.",
                     $response
                 );
-                break;
             case 422:
                 throw new \ChartMogul\Exceptions\SchemaInvalidException(
                     "The ".$this->resourceKey." could not be created or updated.",
                     $response
                 );
-                break;
             case 200:
             case 201:
             case 202:
-            case 204:
                 break;
+            case 204: // HTTP No Content
+                return "";
             default:
                 throw new \ChartMogul\Exceptions\ChartMogulException(
                     $this->resourceKey." request error has occurred.",
                     $response
                 );
-                break;
         }
 
         if (json_last_error() !== JSON_ERROR_NONE) {


### PR DESCRIPTION
Integrators are confused because the simple messages hide detailed messages from API.
It's more straightforward to just print the json, than require customers to catch the correct class and print getResponse().

On HTTP 204 (eg. delete data source) the library returned 'JSON Parse error' in spite of the operation being successful.

There was also some unreachable code.