### PR TITLE
Update Composer version to correct

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.5",
         "php-http/client-implementation": "^1.0",
         "zendframework/zend-diactoros": "^1.3",
         "php-http/guzzle6-adapter": "^1.0",


### PR DESCRIPTION
PHP Chartmogul is not supporting PHP 5.4. It's working only with PHP 5.5 or upper versions.
1) Current version is using a new PHP 5.5 feature (like this https://github.com/chartmogul/chartmogul-php/blob/master/src/Enrichment/Customer.php#L123)
2) `php-http/client-implementation` library currently working with PHP 5.5 or upper. https://packagist.org/packages/php-http/guzzle6-adapter#v1.0.0