### PR TITLE
Fix bug $resourcePath attribute in RequestService.

### DIFF
--- a/src/Service/RequestService.php
+++ b/src/Service/RequestService.php
@@ -44,7 +44,7 @@ class RequestService
      */
     public function setResourcePath($resourcePath)
     {
-        $this->$resourcePath = $resourcePath;
+        $this->resourcePath = $resourcePath;
         return $this;
     }
 
@@ -61,8 +61,8 @@ class RequestService
     {
         $class = $this->resourceClass;
         $path = $class::RESOURCE_PATH;
-        if (isset($this->$resourcePath)) {
-            $path = $this->$resourcePath;
+        if (isset($this->resourcePath)) {
+            $path = $this->resourcePath;
         }
         
         foreach ($this->getNamedParams($path) as $param) {


### PR DESCRIPTION
Hi !

This commit fix a blocking bug.

I detected it, when I tried to use `ChartMogul\Enrichment\Customer::update(...)` method.
I got this two errors :
```
Notice Error: Undefined variable: resourcePath in [/home/aymeric/Projects/pro/SubstancesActives/external-services/vendor/chartmogul/chartmogul-php/src/Service/RequestService.php, line 64]

2017-01-12 12:12:00 Notice: Notice (8): Undefined variable: resourcePath in [/home/aymeric/Projects/pro/SubstancesActives/external-services/vendor/chartmogul/chartmogul-php/src/Service/RequestService.php, line 64]
Trace:
Cake\Error\BaseErrorHandler::handleError() - CORE/src/Error/BaseErrorHandler.php, line 146
ChartMogul\Service\RequestService::applyResourcePath() - ROOT/vendor/chartmogul/chartmogul-php/src/Service/RequestService.php, line 64
ChartMogul\Service\RequestService::update() - ROOT/vendor/chartmogul/chartmogul-php/src/Service/RequestService.php, line 112
ChartMogul\Enrichment\Customer::update() - ROOT/vendor/chartmogul/chartmogul-php/src/Service/UpdateTrait.php, line 23
App\Lib\ChartMogulLib::createOrUpdateCustomer() - APP/Lib/ChartMogulLib.php, line 47
FreshBooks\Shell\ChartMogulShell::pushClients() - ROOT/plugins/FreshBooks/src/Shell/ChartMogulShell.php, line 44
Cake\Console\Shell::runCommand() - CORE/src/Console/Shell.php, line 453
Cake\Console\ShellDispatcher::_dispatch() - CORE/src/Console/ShellDispatcher.php, line 227
Cake\Console\ShellDispatcher::dispatch() - CORE/src/Console/ShellDispatcher.php, line 182
Cake\Console\ShellDispatcher::run() - CORE/src/Console/ShellDispatcher.php, line 128
[main] - ROOT/bin/cake.php, line 34
```