### PR TITLE
Moving classes and fixing get, remove Customer.retrieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ ChartMogul\Configuration::getDefaultConfiguration()
 
 ```php
 try {
-  $dataSources = ChartMogul\Import\DataSource::all();
+  $dataSources = ChartMogul\DataSource::all();
 } catch(\ChartMogul\Exceptions\ForbiddenException $e){
   // handle authentication exception
 } catch(\ChartMogul\Exceptions\ChartMogulException $e){
@@ -90,7 +90,7 @@ Available methods in Import API:
 **Create Datasources**
 
 ```php
-$ds = ChartMogul\Import\DataSource::create([
+$ds = ChartMogul\DataSource::create([
   'name' => 'In-house Billing'
 ]);
 ```
@@ -98,19 +98,19 @@ $ds = ChartMogul\Import\DataSource::create([
 **Get a Datasource by UUID**
 
 ```php
-ChartMogul\Import\DataSource::get($uuid);
+ChartMogul\DataSource::get($uuid);
 ```
 
 **List Datasources**
 
 ```php
-ChartMogul\Import\DataSource::all();
+ChartMogul\DataSource::all();
 ```
 
 **Delete a Datasource**
 
 ```php
-$dataSources = ChartMogul\Import\DataSource::all();
+$dataSources = ChartMogul\DataSource::all();
 $ds = $dataSources->last();
 $ds->destroy();
 ```
@@ -135,22 +135,16 @@ ChartMogul\Import\Customer::create([
 **List Customers**
 
 ```php
-ChartMogul\Import\Customer::all([
+ChartMogul\Customers::all([
   'page' => 1,
   'data_source_uuid' => $ds->uuid
 ]);
 ```
 
-**Get a Customer by UUID**
-
-```php
-ChartMogul\Import\Customer::get($uuid);
-```
-
 **Find Customer By External ID**
 
 ```php
-ChartMogul\Import\Customer::findByExternalId([
+ChartMogul\Customer::findByExternalId([
     "data_source_uuid" => "ds_fef05d54-47b4-431b-aed2-eb6b9e545430",
     "external_id" => "cus_0001"
 ]);
@@ -161,6 +155,128 @@ ChartMogul\Import\Customer::findByExternalId([
 ```php
 $cus = ChartMogul\Import\Customer::all()->last();
 $cus->destroy();
+```
+
+**Get a Customer**
+
+```php
+ChartMogul\Customer::get($uuid);
+```
+
+**Search for Customers**
+
+```php
+ChartMogul\Customer::search('adam@smith.com');
+```
+
+**Merge Customers**
+
+```php
+ChartMogul\Customer::merge([
+    'customer_uuid' => $cus1->uuid
+], [
+    'customer_uuid' => $cus2->uuid
+]);
+
+// alternatively:
+ChartMogul\Customer::merge([
+    'external_id' => $cus1->external_id,
+    'data_source_uuid' => $ds->uuid
+        ], [
+    'external_id' => $cus2->external_id,
+    'data_source_uuid' => $ds->uuid
+]);
+```
+
+**Update a Customer**
+
+```php
+$result = ChartMogul\Customer::update([
+    'customer_uuid' => $cus1->uuid
+        ], [
+    'name' => 'New Name'
+]);
+```
+
+
+#### Customer Attributes
+
+**Retrieve Customer's Attributes**
+
+```php
+$customer = ChartMogul\Customer::get($cus->uuid);
+$customer->attributes;
+
+```
+
+
+#### Tags
+
+**Add Tags to a Customer**
+
+```php
+$customer = ChartMogul\Customer::get($cus->uuid);
+$tags = $customer->addTags("important", "Prio1");
+```
+
+**Add Tags to Customers with email**
+
+```php
+$customers = ChartMogul\Customer::search('adam@smith.com');
+
+foreach ($customers->entries as $customer) {
+    $customer->addTags('foo', 'bar', 'baz');
+}
+```
+
+**Remove Tags from a Customer**
+
+```php
+$customer = ChartMogul\Customer::get($cus->uuid);
+$tags = $customer->removeTags("important", "Prio1");
+```
+
+#### Custom Attributes
+
+**Add Custom Attributes to a Customer**
+
+```php
+$customer = ChartMogul\Customer::get($cus->uuid);
+$custom = $customer->addCustomAttributes(
+    ['type' => 'String', 'key' => 'channel', 'value' => 'Facebook'],
+    ['type' => 'Integer', 'key' => 'age', 'value' => 8 ]
+);
+```
+
+
+**Add Custom Attributes to Customers with email**
+
+```php
+$customers = ChartMogul\Customer::search('adam@smith.com');
+
+foreach ($customers->entries as $customer) {
+    $customer->addCustomAttributes(
+        ['type' => 'String', 'key' => 'channel', 'value' => 'Facebook'],
+        ['type' => 'Integer', 'key' => 'age', 'value' => 8 ]
+    );
+}
+```
+
+**Update Custom Attributes of a Customer**
+
+```php
+$customer = ChartMogul\Customer::get($cus->uuid);
+$custom = $customer->updateCustomAttributes(
+    ['channel' => 'Twitter'],
+    ['age' => 18]
+);
+```
+
+**Remove Custom Attributes from a Customer**
+
+```php
+$customer = ChartMogul\Customer::get($cus->uuid);
+$tags = $customer->removeCustomAttributes("age", "channel");
 ```
 
 #### Plans
@@ -300,148 +416,6 @@ $cus = new ChartMogul\Import\Customer([
 $subscription = $subscriptions->last()->cancel($canceldate);
 ```
 
-### Enrichment API
-
-#### Customers
-
-**Retrieve a Customer**
-
-```php
-ChartMogul\Enrichment\Customer::retrieve($cus->uuid);
-```
-
-**Search for Customers**
-
-```php
-ChartMogul\Enrichment\Customer::search('adam@smith.com');
-```
-
-**List all Customers**
-
-```php
-ChartMogul\Enrichment\Customer::all([
-    'page' => 1
-]);
-```
-
-**Find Customer By External ID**
-
-```php
-ChartMogul\Enrichment\Customer::findByExternalId($external_id);
-```
-
-**Merge Customers**
-
-```php
-ChartMogul\Enrichment\Customer::merge([
-    'customer_uuid' => $cus1->uuid
-], [
-    'customer_uuid' => $cus2->uuid
-]);
-
-// alternatively:
-ChartMogul\Enrichment\Customer::merge([
-    'external_id' => $cus1->external_id,
-    'data_source_uuid' => $ds->uuid
-        ], [
-    'external_id' => $cus2->external_id,
-    'data_source_uuid' => $ds->uuid
-]);
-```
-
-**Update a Customer**
-
-```php
-$result = ChartMogul\Enrichment\Customer::update([
-    'customer_uuid' => $cus1->uuid
-        ], [
-    'name' => 'New Name'
-]);
-```
-
-
-#### Customer Attributes
-
-**Retrieve Customer's Attributes**
-
-```php
-$customer = ChartMogul\Enrichment\Customer::retrieve($cus->uuid);
-$customer->attributes;
-
-```
-
-
-#### Tags
-
-**Add Tags to a Customer**
-
-```php
-$customer = ChartMogul\Enrichment\Customer::retrieve($cus->uuid);
-$tags = $customer->addTags("important", "Prio1");
-```
-
-**Add Tags to Customers with email**
-
-```php
-$customers = ChartMogul\Enrichment\Customer::search('adam@smith.com');
-
-foreach ($customers->entries as $customer) {
-    $customer->addTags('foo', 'bar', 'baz');
-}
-```
-
-**Remove Tags from a Customer**
-
-```php
-$customer = ChartMogul\Enrichment\Customer::retrieve($cus->uuid);
-$tags = $customer->removeTags("important", "Prio1");
-```
-
-
-
-#### Custom Attributes
-
-
-**Add Custom Attributes to a Customer**
-
-```php
-$customer = ChartMogul\Enrichment\Customer::retrieve($cus->uuid);
-$custom = $customer->addCustomAttributes(
-    ['type' => 'String', 'key' => 'channel', 'value' => 'Facebook'],
-    ['type' => 'Integer', 'key' => 'age', 'value' => 8 ]
-);
-```
-
-
-**Add Custom Attributes to Customers with email**
-
-```php
-$customers = ChartMogul\Enrichment\Customer::search('adam@smith.com');
-
-foreach ($customers->entries as $customer) {
-    $customer->addCustomAttributes(
-        ['type' => 'String', 'key' => 'channel', 'value' => 'Facebook'],
-        ['type' => 'Integer', 'key' => 'age', 'value' => 8 ]
-    );
-}
-```
-
-**Update Custom Attributes of a Customer**
-
-```php
-$customer = ChartMogul\Enrichment\Customer::retrieve($cus->uuid);
-$custom = $customer->updateCustomAttributes(
-    ['channel' => 'Twitter'],
-    ['age' => 18]
-);
-```
-
-**Remove Custom Attributes from a Customer**
-
-```php
-$customer = ChartMogul\Enrichment\Customer::retrieve($cus->uuid);
-$tags = $customer->removeCustomAttributes("age", "channel");
-```
 
 ### Metrics API
 

--- a/src/Customer.php
+++ b/src/Customer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ChartMogul\Enrichment;
+namespace ChartMogul;
 
 use ChartMogul\Resource\AbstractResource;
 use ChartMogul\Http\ClientInterface;
@@ -27,9 +27,9 @@ use ChartMogul\Service\UpdateTrait;
  */
 class Customer extends AbstractResource
 {
-    
+
     use UpdateTrait;
-    
+
     /**
      * @ignore
      */
@@ -44,6 +44,7 @@ class Customer extends AbstractResource
     protected $external_id;
     protected $name;
     protected $email;
+    protected $company;
     protected $status;
     protected $customer_since;
     protected $attributes;
@@ -55,7 +56,7 @@ class Customer extends AbstractResource
     protected $billing_system_type;
     protected $currency;
     protected $currency_sign;
-    
+
     // PATCH = Update a customer
     protected $data_source_uuid;
     protected $data_source_uuids;
@@ -86,22 +87,6 @@ class Customer extends AbstractResource
     }
 
     /**
-     * Retrieve a Customer
-     * @param  string               $customer_uuid
-     * @param  ClientInterface|null $client
-     * @return Customer
-     */
-    public static function retrieve($customer_uuid, ClientInterface $client = null)
-    {
-
-        return (new RequestService($client))
-            ->setResourceClass(static::class)
-            ->all([
-                'customer_uuid' => $customer_uuid
-            ]);
-    }
-
-    /**
      * List all Customers
      * @param  array                $data
      * @param  ClientInterface|null $client
@@ -118,7 +103,7 @@ class Customer extends AbstractResource
      * @return Customer
      */
     public static function get($uuid, ClientInterface $client = null) {
-        return Customers::get($data, $client);
+        return Customers::get($uuid, $client);
     }
 
     /**
@@ -128,13 +113,9 @@ class Customer extends AbstractResource
      */
     public static function findByExternalId($externalId)
     {
-        return static::all(
-            [
-                'external_id' => $externalId
-            ]
-        )->entries->first();
+        return static::all(['external_id' => $externalId])->entries->first();
     }
-    
+
     /**
      * Search for Customers
      * @param  string                $email

--- a/src/Customers.php
+++ b/src/Customers.php
@@ -1,18 +1,23 @@
 <?php
 
-namespace ChartMogul\Enrichment;
+namespace ChartMogul;
 
 use ChartMogul\Resource\AbstractResource;
 use ChartMogul\Http\ClientInterface;
 use ChartMogul\Resource\EntryTrait;
 use ChartMogul\Service\AllTrait;
 use ChartMogul\Service\GetTrait;
+use ChartMogul\Service\CreateTrait;
+use ChartMogul\Service\DestroyTrait;
+
 
 class Customers extends AbstractResource
 {
+    use CreateTrait;
     use EntryTrait;
     use AllTrait;
     use GetTrait;
+    use DestroyTrait;
 
     /**
      * @ignore

--- a/src/DataSource.php
+++ b/src/DataSource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ChartMogul\Import;
+namespace ChartMogul;
 
 use ChartMogul\Resource\AbstractResource;
 use ChartMogul\Service\CreateTrait;

--- a/src/Plan.php
+++ b/src/Plan.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ChartMogul\Import;
+namespace ChartMogul;
 
 use ChartMogul\Resource\AbstractResource;
 use ChartMogul\Service\GetTrait;
@@ -14,7 +14,7 @@ use ChartMogul\Service\DestroyTrait;
 */
 class Plan extends AbstractResource
 {
-    
+
     use AllTrait;
     use CreateTrait;
     use DestroyTrait;
@@ -41,7 +41,7 @@ class Plan extends AbstractResource
     public $external_id;
 
     public $data_source_uuid;
-    
+
     public static function update(array $id = [], array $data = [], ClientInterface $client = null)
     {
         return (new RequestService($client))


### PR DESCRIPTION
Moving data source & plans from Import; customers from Enrichment; removing Import/Customers.
Tests are green.
Will release as 1.1.0, because it changes namespaces, but let's keep in sync with other libs that are now 1.x