### PR TITLE
Ping endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ ChartMogul\Configuration::getDefaultConfiguration()
     ->setSecretKey('<YOUR_SECRET_KEY>');
 ```
 
+
+### Test your authentication
+```php
+print_r(ChartMogul\Ping::ping()->data);
+```
+
 ## Usage
 
 ```php

--- a/src/Ping.php
+++ b/src/Ping.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ChartMogul;
+
+use ChartMogul\Resource\AbstractResource;
+use ChartMogul\Service\AllTrait;
+
+/**
+* @codeCoverageIgnore
+* @property-read string $uuid
+*/
+class Ping extends AbstractResource
+{
+    use AllTrait;
+
+    /**
+     * @ignore
+     */
+    const RESOURCE_PATH = '/v1/ping';
+    /**
+     * @ignore
+     */
+    const RESOURCE_NAME = 'Ping';
+
+    public $data;
+
+    public static function ping(ClientInterface $client = null)
+    {
+        return Ping::all();
+    }
+}


### PR DESCRIPTION
Simple implementation for ping authentication endpoint.
Internally uses `all()`, which is more general, but can handle this case nicely.