### PR TITLE
namespace Import -> ChartMogul, backwards compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ or in `composer.json`:
 ```json
 {
     "require": {
-        "chartmogul/chartmogul-php": "1.0.0"
+        "chartmogul/chartmogul-php": "1.1.2"
     }
 }
 ```

--- a/src/Customer.php
+++ b/src/Customer.php
@@ -249,7 +249,7 @@ class Customer extends AbstractResource
     }
 
     /**
-     * Find a Customer Invoices
+     * Find customer's invoices
      * @param  array  $options
      * @return \Doctrine\Common\Collections\ArrayCollection | Customer
      * @deprecated Use Import\CustomerInvoices.

--- a/src/Customer.php
+++ b/src/Customer.php
@@ -103,7 +103,10 @@ class Customer extends AbstractResource
      */
     public static function findByExternalId($externalId)
     {
-        return static::all(['external_id' => $externalId])->entries->first();
+        if (gettype($externalId) == 'string') {
+            $externalId = ['external_id' => $externalId];
+        }
+        return static::all($externalId)->entries->first();
     }
 
     /**
@@ -132,7 +135,7 @@ class Customer extends AbstractResource
      */
     public static function merge($from, $into, ClientInterface $client = null)
     {
-        $response = (new static([], $client))
+        (new static([], $client))
             ->getClient()
             ->setResourcekey(static::class)
             ->send('/v1/customers/merges', 'POST', [
@@ -228,5 +231,35 @@ class Customer extends AbstractResource
 
         $this->attributes['custom'] = $result['custom'];
         return $result['custom'];
+    }
+
+    /**
+     * Find a Customer Subscriptions
+     * @param  array  $options
+     * @return \Doctrine\Common\Collections\ArrayCollection | Customer
+     * @deprecated Use Import\Subscription.
+     */
+    public function subscriptions(array $options = [])
+    {
+        if (!isset($this->subscriptions)) {
+            $options['customer_uuid'] = $this->uuid;
+            $this->subscriptions = Subscription::all($options);
+        }
+        return $this->subscriptions;
+    }
+
+    /**
+     * Find a Customer Invoices
+     * @param  array  $options
+     * @return \Doctrine\Common\Collections\ArrayCollection | Customer
+     * @deprecated Use Import\CustomerInvoices.
+     */
+    public function invoices(array $options = [])
+    {
+        if (!isset($this->invoices)) {
+            $options['customer_uuid'] = $this->uuid;
+            $this->invoices = CustomerInvoices::all($options)->invoices;
+        }
+        return $this->invoices;
     }
 }

--- a/src/CustomerInvoices.php
+++ b/src/CustomerInvoices.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace ChartMogul;
+
+use ChartMogul\Resource\AbstractResource;
+use ChartMogul\Http\ClientInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+
+class CustomerInvoices extends AbstractResource
+{
+
+    use \ChartMogul\Service\CreateTrait;
+    use \ChartMogul\Service\AllTrait;
+
+    /**
+     * @ignore
+     */
+    const RESOURCE_PATH = '/v1/import/customers/:customer_uuid/invoices';
+    /**
+     * @ignore
+     */
+    const RESOURCE_NAME = 'Invoices';
+
+    public $invoices = [];
+
+    public $customer_uuid;
+
+    public function __construct(array $attr = [], ClientInterface $client = null)
+    {
+        parent::__construct($attr, $client);
+
+        $this->invoices = new ArrayCollection($this->invoices);
+        foreach ($this->invoices as $key => $item) {
+            $this->setInvoice($key, $item);
+        }
+    }
+
+    protected function setInvoice($index, $invoice)
+    {
+
+        if ($invoice instanceof \ChartMogul\Import\Invoice) {
+            $this->invoices[$index] =$invoice;
+        } elseif (is_array($invoice)) {
+            $this->invoices[$index] = new \ChartMogul\Import\Invoice($invoice);
+        }
+    }
+}

--- a/src/Import/Customer.php
+++ b/src/Import/Customer.php
@@ -2,84 +2,9 @@
 
 namespace ChartMogul\Import;
 
-use ChartMogul\Resource\AbstractResource;
-
 /**
  * @deprecated Use ChartMogul\Customer, Import\CustomerInvoices or Import\Subscription.
- * @property-read string $uuid
  */
-class Customer extends AbstractResource
-{
+class Customer extends ChartMogul\Customer {
 
-    use \ChartMogul\Service\CreateTrait;
-    use \ChartMogul\Service\AllTrait;
-    use \ChartMogul\Service\DestroyTrait;
-
-    /**
-     * @ignore
-     */
-    const RESOURCE_PATH = '/v1/import/customers';
-    /**
-     * @ignore
-     */
-    const RESOURCE_NAME = 'Customer';
-    /**
-     * @ignore
-     */
-    const ROOT_KEY = 'customers';
-
-    protected $uuid;
-
-    public $external_id;
-    public $name;
-    public $email;
-    public $company;
-    public $country;
-    public $state;
-    public $city;
-    public $zip;
-    public $data_source_uuid;
-    public $lead_created_at;
-    public $free_trial_started_at;
-
-    /**
-     * Find a Customer by External ID
-     * @param string $externalId
-     * @return Customer
-     * @deprecated Use ChartMogul\Customer
-     */
-    public static function findByExternalId(array $options = [])
-    {
-        return static::all($options)->first();
-    }
-
-    /**
-     * Find a Customer Subscriptions
-     * @param  array  $options
-     * @return \Doctrine\Common\Collections\ArrayCollection | Customer
-     * @deprecated Use Import\Subscription.
-     */
-    public function subscriptions(array $options = [])
-    {
-        if (!isset($this->subscriptions)) {
-            $options['customer_uuid'] = $this->uuid;
-            $this->subscriptions = Subscription::all($options);
-        }
-        return $this->subscriptions;
-    }
-
-    /**
-     * Find a Customer Invoices
-     * @param  array  $options
-     * @return \Doctrine\Common\Collections\ArrayCollection | Customer
-     * @deprecated Use Import\CustomerInvoices.
-     */
-    public function invoices(array $options = [])
-    {
-        if (!isset($this->invoices)) {
-            $options['customer_uuid'] = $this->uuid;
-            $this->invoices = CustomerInvoices::all($options)->invoices;
-        }
-        return $this->invoices;
-    }
 }

--- a/src/Import/CustomerInvoices.php
+++ b/src/Import/CustomerInvoices.php
@@ -2,46 +2,9 @@
 
 namespace ChartMogul\Import;
 
-use ChartMogul\Resource\AbstractResource;
-use ChartMogul\Http\ClientInterface;
-use Doctrine\Common\Collections\ArrayCollection;
+/**
+ * @deprecated Use \ChartMogul\CustomerInvoices
+ */
+class CustomerInvoices extends \ChartMogul\CustomerInvoices {
 
-class CustomerInvoices extends AbstractResource
-{
-
-    use \ChartMogul\Service\CreateTrait;
-    use \ChartMogul\Service\AllTrait;
-
-    /**
-     * @ignore
-     */
-    const RESOURCE_PATH = '/v1/import/customers/:customer_uuid/invoices';
-    /**
-     * @ignore
-     */
-    const RESOURCE_NAME = 'Invoices';
-
-    public $invoices = [];
-
-    public $customer_uuid;
-
-    public function __construct(array $attr = [], ClientInterface $client = null)
-    {
-        parent::__construct($attr, $client);
-
-        $this->invoices = new ArrayCollection($this->invoices);
-        foreach ($this->invoices as $key => $item) {
-            $this->setInvoice($key, $item);
-        }
-    }
-
-    protected function setInvoice($index, $invoice)
-    {
-
-        if ($invoice instanceof \ChartMogul\Import\Invoice) {
-            $this->invoices[$index] =$invoice;
-        } elseif (is_array($invoice)) {
-            $this->invoices[$index] = new \ChartMogul\Import\Invoice($invoice);
-        }
-    }
 }

--- a/src/Import/DataSource.php
+++ b/src/Import/DataSource.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ChartMogul\Import;
+
+/**
+ * @deprecated Use ChartMogul\DataSource
+ */
+class DataSource extends ChartMogul\DataSource {
+
+}

--- a/src/Import/Invoice.php
+++ b/src/Import/Invoice.php
@@ -2,65 +2,9 @@
 
 namespace ChartMogul\Import;
 
-use ChartMogul\Import\LineItems\AbstractLineItem;
-use ChartMogul\Import\LineItems\OneTime;
-use ChartMogul\Import\LineItems\Subscription as SubsItem;
-use ChartMogul\Import\Transactions\AbstractTransaction;
-use ChartMogul\Import\Transactions\Payment;
-use ChartMogul\Import\Transactions\Refund;
-use Doctrine\Common\Collections\ArrayCollection;
-
 /**
- * @property-read string $uuid
+ * @deprecated Use \ChartMogul\Invoice
  */
-class Invoice extends \ChartMogul\Resource\AbstractModel
-{
+class Invoice extends \ChartMogul\Invoice {
 
-    protected $uuid;
-
-    public $date;
-    public $currency;
-    public $line_items = [];
-    public $transactions = [];
-    public $external_id;
-    public $due_date;
-
-    public function __construct(array $attr = [])
-    {
-        parent::__construct($attr);
-
-        $this->line_items = new ArrayCollection($this->line_items);
-        foreach ($this->line_items as $key => $item) {
-            $this->setLineItem($key, $item);
-        }
-
-        $this->transactions = new ArrayCollection($this->transactions);
-        foreach ($this->transactions as $key => $item) {
-            $this->setTransaction($key, $item);
-        }
-    }
-
-    protected function setLineItem($index, $line)
-    {
-
-        if ($line instanceof AbstractLineItem) {
-            $this->line_items[$index] = $line;
-        } elseif (is_array($line) && isset($line['type']) && $line['type'] === 'one_time') {
-            $this->line_items[$index] = new OneTime($line);
-        } elseif (is_array($line) && isset($line['type']) && $line['type'] === 'subscription') {
-            $this->line_items[$index] = new SubsItem($line);
-        }
-    }
-
-    protected function setTransaction($index, $tr)
-    {
-
-        if ($tr instanceof AbstractTransaction) {
-            $this->transactions[$index] = $tr;
-        } elseif (is_array($tr) && isset($tr['type']) && $tr['type'] === 'payment') {
-            $this->transactions[$index] = new Payment($tr);
-        } elseif (is_array($tr) && isset($tr['type']) && $tr['type'] === 'refund') {
-            $this->transactions[$index] = new Refund($tr);
-        }
-    }
 }

--- a/src/Import/LineItems/AbstractLineItem.php
+++ b/src/Import/LineItems/AbstractLineItem.php
@@ -4,20 +4,8 @@ namespace ChartMogul\Import\LineItems;
 
 /**
 * @codeCoverageIgnore
-* @property-read string $uuid
+* @deprecated
 */
-abstract class AbstractLineItem extends \ChartMogul\Resource\AbstractModel
+abstract class AbstractLineItem extends \ChartMogul\AbstractLineItem
 {
-
-    protected $uuid;
-
-    public $type;
-    public $amount_in_cents;
-    public $quantity;
-    public $discount_amount_in_cents;
-    public $discount_code;
-    public $tax_amount_in_cents;
-    public $external_id;
-
-    public $invoice_uuid;
 }

--- a/src/Import/LineItems/OneTime.php
+++ b/src/Import/LineItems/OneTime.php
@@ -4,10 +4,8 @@ namespace ChartMogul\Import\LineItems;
 
 /**
 * @codeCoverageIgnore
+* @deprecated Use ChartMogul\OneTime
 */
-class OneTime extends AbstractLineItem
-{
+class OneTime extends ChartMogul\OneTime {
 
-    public $type = 'one_time';
-    public $description;
 }

--- a/src/Import/LineItems/Subscription.php
+++ b/src/Import/LineItems/Subscription.php
@@ -4,17 +4,8 @@ namespace ChartMogul\Import\LineItems;
 
 /**
 * @codeCoverageIgnore
+* @deprecated Use ChartMogul\Subscription
 */
-class Subscription extends AbstractLineItem
-{
-
-    public $type = 'subscription';
-    public $subscription_external_id;
-    public $service_period_start;
-    public $service_period_end;
-    public $cancelled_at;
-    public $prorated;
-
-    protected $subscription_uuid;
-    public $plan_uuid;
+class Subscription extends Subscription{
+    
 }

--- a/src/Import/Plan.php
+++ b/src/Import/Plan.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ChartMogul\Import;
+
+/**
+ * @deprecated Use ChartMogul\Plan
+ */
+class Plan extends ChartMogul\Plan {
+
+}

--- a/src/Import/Subscription.php
+++ b/src/Import/Subscription.php
@@ -2,90 +2,9 @@
 
 namespace ChartMogul\Import;
 
-use ChartMogul\Resource\AbstractResource;
-use \ChartMogul\Service\CreateTrait;
-use \ChartMogul\Service\AllTrait;
-
 /**
- * @property-read string $uuid
- * @property-read string $external_id
- * @property-read string $cancellation_dates
- * @property-read string $plan_uuid
- * @property-read string $data_source_uuid
+ * @deprecated Use \ChartMogul\Subscription
  */
-class Subscription extends AbstractResource
-{
+class Subscription extends \ChartMogul\Subscription {
 
-    use CreateTrait;
-    use AllTrait;
-
-    /**
-     * @ignore
-     */
-    const RESOURCE_PATH = '/v1/import/customers/:customer_uuid/subscriptions';
-    /**
-     * @ignore
-     */
-    const ROOT_KEY = 'subscriptions';
-
-    const RESOURCE_NAME = 'Subscription';
-
-
-    protected $uuid;
-    protected $external_id;
-    protected $cancellation_dates = [];
-
-    protected $plan_uuid;
-    protected $data_source_uuid;
-
-
-
-    private function cancellation($payload)
-    {
-        $response = $this->getClient()->send(
-            '/v1/import/subscriptions/'.$this->uuid,
-            'PATCH',
-            $payload
-        );
-        $this->cancellation_dates = $response['cancellation_dates'];
-        return $this;
-    }
-
-    /**
-     * Cancels a subscription that was generated from an imported invoice.
-     * @param  string $cancelledAt The time at which the subscription was cancelled.
-     * @return Subscription
-     */
-    public function cancel($cancelledAt)
-    {
-        return $this->cancellation([
-            'cancelled_at' => $cancelledAt
-        ]);
-    }
-
-    /**
-     * Changes dates of cancellation for a subscription.
-     * @param  array $cancellationDates The array of times (strings) at which the subscription was cancelled.
-     * @return Subscription
-     */
-    public function setCancellationDates($cancellationDates)
-    {
-        return $this->cancellation([
-            'cancellation_dates' => $cancellationDates
-        ]);
-    }
-
-    /**
-     * @param array $data
-     * @param ClientInterface|null $client
-     * @return ArrayCollection|self
-     */
-    public static function fromArray(array $data, \ChartMogul\Http\ClientInterface $client = null)
-    {
-        $result = parent::fromArray($data, $client);
-        if (isset($data["customer_uuid"])) {
-            $result->customer_uuid = $data["customer_uuid"];
-        }
-        return $result;
-    }
 }

--- a/src/Import/Transactions/AbstractTransaction.php
+++ b/src/Import/Transactions/AbstractTransaction.php
@@ -2,24 +2,10 @@
 
 namespace ChartMogul\Import\Transactions;
 
-use ChartMogul\Resource\AbstractResource;
-
 /**
  * @property-read string $uuid
+ * @deprecated Use ChartMogul\AbstractTransaction
  */
-abstract class AbstractTransaction extends AbstractResource
-{
-
-    use \ChartMogul\Service\CreateTrait;
-
-    const RESOURCE_PATH = '/v1/import/invoices/:invoice_uuid/transactions';
-
-    protected $uuid;
-
-    public $type;
-    public $date;
-    public $result;
-    public $external_id;
-
-    public $invoice_uuid;
+abstract class AbstractTransaction extends ChartMogul\AbstractTransaction {
+    
 }

--- a/src/Import/Transactions/Payment.php
+++ b/src/Import/Transactions/Payment.php
@@ -3,13 +3,9 @@
 namespace ChartMogul\Import\Transactions;
 
 /**
-* @codeCoverageIgnore
-*/
-class Payment extends AbstractTransaction
-{
-
-    const RESOURCE_NAME= 'Payment Transaction';
-
-
-    public $type = 'payment';
+ * @codeCoverageIgnore
+ * @deprecated Use ChartMogul\Payment
+ */
+class Payment extends ChartMogul\Payment {
+    
 }

--- a/src/Import/Transactions/Refund.php
+++ b/src/Import/Transactions/Refund.php
@@ -3,12 +3,9 @@
 namespace ChartMogul\Import\Transactions;
 
 /**
-* @codeCoverageIgnore
-*/
-class Refund extends AbstractTransaction
-{
-
-    const RESOURCE_NAME= 'Refund Transaction';
-
-    public $type = 'refund';
+ * @codeCoverageIgnore
+ * @deprecated Use ChartMogul\Refund
+ */
+class Refund extends ChartMogul\Refund {
+    
 }

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace ChartMogul;
+
+use ChartMogul\LineItems\AbstractLineItem;
+use ChartMogul\LineItems\OneTime;
+use ChartMogul\LineItems\Subscription as SubsItem;
+use ChartMogul\Transactions\AbstractTransaction;
+use ChartMogul\Transactions\Payment;
+use ChartMogul\Transactions\Refund;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @property-read string $uuid
+ */
+class Invoice extends \ChartMogul\Resource\AbstractModel
+{
+
+    protected $uuid;
+
+    public $date;
+    public $currency;
+    public $line_items = [];
+    public $transactions = [];
+    public $external_id;
+    public $due_date;
+
+    public function __construct(array $attr = [])
+    {
+        parent::__construct($attr);
+
+        $this->line_items = new ArrayCollection($this->line_items);
+        foreach ($this->line_items as $key => $item) {
+            $this->setLineItem($key, $item);
+        }
+
+        $this->transactions = new ArrayCollection($this->transactions);
+        foreach ($this->transactions as $key => $item) {
+            $this->setTransaction($key, $item);
+        }
+    }
+
+    protected function setLineItem($index, $line)
+    {
+
+        if ($line instanceof AbstractLineItem) {
+            $this->line_items[$index] = $line;
+        } elseif (is_array($line) && isset($line['type']) && $line['type'] === 'one_time') {
+            $this->line_items[$index] = new OneTime($line);
+        } elseif (is_array($line) && isset($line['type']) && $line['type'] === 'subscription') {
+            $this->line_items[$index] = new SubsItem($line);
+        }
+    }
+
+    protected function setTransaction($index, $tr)
+    {
+
+        if ($tr instanceof AbstractTransaction) {
+            $this->transactions[$index] = $tr;
+        } elseif (is_array($tr) && isset($tr['type']) && $tr['type'] === 'payment') {
+            $this->transactions[$index] = new Payment($tr);
+        } elseif (is_array($tr) && isset($tr['type']) && $tr['type'] === 'refund') {
+            $this->transactions[$index] = new Refund($tr);
+        }
+    }
+}

--- a/src/LineItems/AbstractLineItem.php
+++ b/src/LineItems/AbstractLineItem.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ChartMogul\LineItems;
+
+/**
+* @codeCoverageIgnore
+* @property-read string $uuid
+*/
+abstract class AbstractLineItem extends \ChartMogul\Resource\AbstractModel
+{
+
+    protected $uuid;
+
+    public $type;
+    public $amount_in_cents;
+    public $quantity;
+    public $discount_amount_in_cents;
+    public $discount_code;
+    public $tax_amount_in_cents;
+    public $external_id;
+
+    public $invoice_uuid;
+}

--- a/src/LineItems/OneTime.php
+++ b/src/LineItems/OneTime.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ChartMogul\LineItems;
+
+/**
+* @codeCoverageIgnore
+*/
+class OneTime extends AbstractLineItem
+{
+
+    public $type = 'one_time';
+    public $description;
+}

--- a/src/LineItems/Subscription.php
+++ b/src/LineItems/Subscription.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ChartMogul\LineItems;
+
+/**
+* @codeCoverageIgnore
+*/
+class Subscription extends AbstractLineItem
+{
+
+    public $type = 'subscription';
+    public $subscription_external_id;
+    public $service_period_start;
+    public $service_period_end;
+    public $cancelled_at;
+    public $prorated;
+
+    protected $subscription_uuid;
+    public $plan_uuid;
+}

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace ChartMogul;
+
+use \ChartMogul\Resource\AbstractResource;
+use \ChartMogul\Service\CreateTrait;
+use \ChartMogul\Service\AllTrait;
+
+/**
+ * @property-read string $uuid
+ * @property-read string $external_id
+ * @property-read string $cancellation_dates
+ * @property-read string $plan_uuid
+ * @property-read string $data_source_uuid
+ */
+class Subscription extends AbstractResource
+{
+
+    use CreateTrait;
+    use AllTrait;
+
+    /**
+     * @ignore
+     */
+    const RESOURCE_PATH = '/v1/import/customers/:customer_uuid/subscriptions';
+    /**
+     * @ignore
+     */
+    const ROOT_KEY = 'subscriptions';
+
+    const RESOURCE_NAME = 'Subscription';
+
+
+    protected $uuid;
+    protected $external_id;
+    protected $cancellation_dates = [];
+
+    protected $plan_uuid;
+    protected $data_source_uuid;
+
+
+
+    private function cancellation($payload)
+    {
+        $response = $this->getClient()->send(
+            '/v1/import/subscriptions/'.$this->uuid,
+            'PATCH',
+            $payload
+        );
+        $this->cancellation_dates = $response['cancellation_dates'];
+        return $this;
+    }
+
+    /**
+     * Cancels a subscription that was generated from an imported invoice.
+     * @param  string $cancelledAt The time at which the subscription was cancelled.
+     * @return Subscription
+     */
+    public function cancel($cancelledAt)
+    {
+        return $this->cancellation([
+            'cancelled_at' => $cancelledAt
+        ]);
+    }
+
+    /**
+     * Changes dates of cancellation for a subscription.
+     * @param  array $cancellationDates The array of times (strings) at which the subscription was cancelled.
+     * @return Subscription
+     */
+    public function setCancellationDates($cancellationDates)
+    {
+        return $this->cancellation([
+            'cancellation_dates' => $cancellationDates
+        ]);
+    }
+
+    /**
+     * @param array $data
+     * @param ClientInterface|null $client
+     * @return ArrayCollection|self
+     */
+    public static function fromArray(array $data, \ChartMogul\Http\ClientInterface $client = null)
+    {
+        $result = parent::fromArray($data, $client);
+        if (isset($data["customer_uuid"])) {
+            $result->customer_uuid = $data["customer_uuid"];
+        }
+        return $result;
+    }
+}

--- a/src/Transactions/AbstractTransaction.php
+++ b/src/Transactions/AbstractTransaction.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ChartMogul\Transactions;
+
+use ChartMogul\Resource\AbstractResource;
+
+/**
+ * @property-read string $uuid
+ */
+abstract class AbstractTransaction extends AbstractResource
+{
+
+    use \ChartMogul\Service\CreateTrait;
+
+    const RESOURCE_PATH = '/v1/import/invoices/:invoice_uuid/transactions';
+
+    protected $uuid;
+
+    public $type;
+    public $date;
+    public $result;
+    public $external_id;
+
+    public $invoice_uuid;
+}

--- a/src/Transactions/Payment.php
+++ b/src/Transactions/Payment.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ChartMogul\Transactions;
+
+/**
+* @codeCoverageIgnore
+*/
+class Payment extends AbstractTransaction
+{
+
+    const RESOURCE_NAME= 'Payment Transaction';
+
+
+    public $type = 'payment';
+}

--- a/src/Transactions/Refund.php
+++ b/src/Transactions/Refund.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ChartMogul\Transactions;
+
+/**
+* @codeCoverageIgnore
+*/
+class Refund extends AbstractTransaction
+{
+
+    const RESOURCE_NAME= 'Refund Transaction';
+
+    public $type = 'refund';
+}


### PR DESCRIPTION
* moved classes from Import to main namespace
* change is backwards compatible (added `Plan` and `DataSource` placeholders back to `Import`)
* all moved classes have deprecated subclasses in their original places
* will cause problems if you `use /ChartMogul` and `use /ChartMogul/Import`, then just remove the second `use`.