### PR TITLE
.get now aliased by .retrieve & fixed; Removed Import from CustomerIn…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 /coverage
 test.php
 /nbproject/
+*.cache

--- a/src/CustomerInvoices.php
+++ b/src/CustomerInvoices.php
@@ -38,10 +38,10 @@ class CustomerInvoices extends AbstractResource
     protected function setInvoice($index, $invoice)
     {
 
-        if ($invoice instanceof \ChartMogul\Import\Invoice) {
-            $this->invoices[$index] =$invoice;
+        if ($invoice instanceof \ChartMogul\Invoice) {
+            $this->invoices[$index] = $invoice;
         } elseif (is_array($invoice)) {
-            $this->invoices[$index] = new \ChartMogul\Import\Invoice($invoice);
+            $this->invoices[$index] = new \ChartMogul\Invoice($invoice);
         }
     }
 }

--- a/src/Service/GetTrait.php
+++ b/src/Service/GetTrait.php
@@ -13,10 +13,15 @@ trait GetTrait
      * Get a single resource by UUID.
      * @return resource
      */
-    public static function get($uuid, ClientInterface $client = null)
+    public static function retrieve($uuid, ClientInterface $client = null)
     {
         return (new RequestService($client))
-            ->setResource($this)
+            ->setResourceClass(static::class)
             ->get($uuid);
+    }
+
+    public static function get($uuid, ClientInterface $client = null)
+    {
+        return static::retrieve($uuid, $client);
     }
 }


### PR DESCRIPTION
Broken `get()` reported #23
* fixed get and added retrieve alias, to make it similar to other client libs.
* removing deprecated dependency in `CustomerInvoices.php`