### PR TITLE
Fix Travis Build on php 7.1 [ch14742]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
 
 before_script:
   - composer install
-  - if [[ "$TRAVIS_PHP_VERSION" == '7.1' ]]; composer require --no-update phpunit/phpunit:^7; fi
+  - if [[ "$TRAVIS_PHP_VERSION" == '7.1' ]]; then composer require phpunit/phpunit:^7; fi
 
 script:
   - if [[ "$TRAVIS_PHP_VERSION" == '7.1' ]]; then vendor/bin/phpunit; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
 
 before_script:
   - composer install
+  - if [[ "$TRAVIS_PHP_VERSION" == '7.1' ]]; composer require --no-update phpunit/phpunit:^7; fi
 
 script:
-  - phpunit
+  - if [[ "$TRAVIS_PHP_VERSION" == '7.1' ]]; then vendor/bin/phpunit; fi
+  - if [[ "$TRAVIS_PHP_VERSION" != '7.1' ]]; then phpunit ; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ RUN chmod a+x /usr/local/bin/composer
 RUN apt-get update && apt-get  install -y git unzip
 ARG VERSION
 RUN composer global require hirak/prestissimo
-RUN composer global require phpunit/phpunit:^7
+RUN if [ "$VERSION" = "7.1" ]; then \
+    composer global require phpunit/phpunit:^7;  else \
+    composer global require phpunit/phpunit:^8; fi
 RUN pecl install xdebug-2.7.2;
 RUN docker-php-ext-enable xdebug
 ENV PATH="${PATH}:/root/.composer/vendor/bin"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "zendframework/zend-diactoros": "^1.3",
         "php-http/guzzle6-adapter": "^2.0",
         "doctrine/collections": "^1.3",
-        "stechstudio/backoff": "^1.0"
+        "stechstudio/backoff": "^1.0",
+        "phpunit/phpunit": "^7"
 
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,7 @@
         "zendframework/zend-diactoros": "^1.3",
         "php-http/guzzle6-adapter": "^2.0",
         "doctrine/collections": "^1.3",
-        "stechstudio/backoff": "^1.0",
-        "phpunit/phpunit": "^7"
-
+        "stechstudio/backoff": "^1.0"
     },
     "require-dev": {
         "php-http/mock-client": "^1.3",


### PR DESCRIPTION
Travis has globally phpunit 8 installed. But according to [this](https://phpunit.de/supported-versions.html) php 7.1 requires phpunit 7. This PR manually installs phpunit 7 instead of using the global phpunit when testing on php 7.1