### PR TITLE
Add support for subscription sets [ch16184]

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ $cus = ChartMogul\Customer::all()->first();
 
 $line_itme_1 = new ChartMogul\LineItems\Subscription([
     'subscription_external_id' => "sub_0001",
+    'subscription_set_external_id' => 'set_0001',
     'plan_uuid' =>  $plan->uuid,
     'service_period_start' =>  "2015-11-01 00:00:00",
     'service_period_end' =>  "2015-12-01 00:00:00",

--- a/src/LineItems/Subscription.php
+++ b/src/LineItems/Subscription.php
@@ -10,6 +10,7 @@ class Subscription extends AbstractLineItem
 
     public $type = 'subscription';
     public $subscription_external_id;
+    public $subscription_set_external_id;
     public $service_period_start;
     public $service_period_end;
     public $cancelled_at;

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -9,6 +9,7 @@ use \ChartMogul\Service\AllTrait;
 /**
  * @property-read string $uuid
  * @property-read string $external_id
+ * @property-read string $subscription_set_external_id
  * @property-read string $cancellation_dates
  * @property-read string $plan_uuid
  * @property-read string $data_source_uuid
@@ -33,6 +34,7 @@ class Subscription extends AbstractResource
 
     protected $uuid;
     protected $external_id;
+    protected $subscription_set_external_id;
     protected $cancellation_dates;
 
     protected $plan_uuid;

--- a/tests/Unit/SubscriptionTest.php
+++ b/tests/Unit/SubscriptionTest.php
@@ -15,6 +15,7 @@ class SubscriptionTest extends \PHPUnit\Framework\TestCase
         {
             "uuid": "sub_dd169c42-e127-4637-8b8f-a239b248e3cd",
             "external_id": "abc",
+            "subscription_set_external_id": "set_001",
             "cancellation_dates": [],
             "plan_uuid": "pl_d6fe6904-8319-11e7-82b4-ffedd86c182a",
             "data_source_uuid": "ds_637442a6-8319-11e7-a280-1f28ec01465c"
@@ -49,6 +50,7 @@ class SubscriptionTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($result[0] instanceof Subscription);
         $this->assertEquals("cus_f466e33d-ff2b-4a11-8f85-417eb02157a7", $result->customer_uuid);
         $this->assertEquals("sub_dd169c42-e127-4637-8b8f-a239b248e3cd", $result[0]->uuid);
+        $this->assertEquals("set_001", $result[0]->subscription_set_external_id);
         $this->assertEquals(2, $result->current_page);
         $this->assertEquals(3, $result->total_pages);
     }


### PR DESCRIPTION
This PR allows for support for subscription sets. It adds a subscription_set_external_id attribute to the following objects:

* `ChartMogul\LineItems`
* `ChartMogul\Subscription`.