### PR TITLE
Provide support for Plan Group API [ch19607]

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,57 @@ $plan = ChartMogul\Plan::update(["plan_uuid" => $plan->uuid], [
 ]);
 ```
 
+### Plan Groups
+
+**Create a Plan Group**
+
+```php
+ChartMogul\PlanGroup::create([
+    "name" => "Bronze Plan",
+    "plans" => [$plan_uuid_1, $plan_uuid_2],
+]);
+```
+
+**Get a Plan Group by UUID**
+
+```php
+ChartMogul\PlanGroup::retrieve($uuid);
+```
+
+**List Plan Groups**
+
+```php
+$plan_groups = ChartMogul\PlanGroup::all([
+  'page' => 1
+]);
+```
+
+**Delete A Plan Group**
+
+```php
+$plan_group = ChartMogul\PlanGroup::all()->last();
+$plan_group->destroy();
+```
+
+**Update A Plan Group**
+
+```php
+$plan_group = ChartMogul\PlanGroup::update(
+  ["plan_group_uuid" => $plan_group->uuid],
+  [
+  "name" => "A new plan group name",
+  "plans" => [$plan_uuid_1, $plan_uuid_2]
+]);
+```
+
+**List Plans In A Plan Group**
+
+```php
+$plan_group_plans = ChartMogul\PlanGroups\Plan::all(
+  ["plan_group_uuid" => $plan_group->uuid]
+);
+```
+
 ### Invoices
 
 **Import Invoices**

--- a/src/PlanGroup.php
+++ b/src/PlanGroup.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace ChartMogul;
+
+use ChartMogul\Resource\AbstractResource;
+use ChartMogul\Service\GetTrait;
+use ChartMogul\Service\CreateTrait;
+use ChartMogul\Service\AllTrait;
+use ChartMogul\Service\UpdateTrait;
+use ChartMogul\Service\DestroyTrait;
+
+/**
+* @codeCoverageIgnore
+* @property-read string $uuid
+*/
+class PlanGroup extends AbstractResource
+{
+
+    use AllTrait;
+    use CreateTrait;
+    use UpdateTrait;
+    use DestroyTrait;
+    use GetTrait;
+
+    /**
+     * @ignore
+     */
+    const RESOURCE_PATH = '/v1/plan_groups';
+    const RESOURCE_ID = 'plan_group_uuid';
+    /**
+     * @ignore
+     */
+    const RESOURCE_NAME = 'PlanGroup';
+    /**
+     * @ignore
+     */
+    const ROOT_KEY = 'plan_groups';
+
+    protected $uuid;
+    protected $plans_count;
+
+    public $name;
+    public $plans = [];
+}

--- a/src/PlanGroups/Plan.php
+++ b/src/PlanGroups/Plan.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ChartMogul\PlanGroups;
+
+use ChartMogul\Resource\AbstractResource;
+use ChartMogul\Service\AllTrait;
+
+/**
+* @codeCoverageIgnore
+* @property-read string $uuid
+*/
+class Plan extends AbstractResource
+{
+    use AllTrait;
+
+    /**
+     * @ignore
+     */
+    const RESOURCE_PATH = '/v1/plan_groups/:plan_group_uuid/plans';
+    /**
+     * @ignore
+     */
+    const ROOT_KEY = 'plans';
+
+    protected $uuid;
+
+    public $name;
+    public $interval_count;
+    public $interval_unit;
+    public $external_id;
+    public $data_source_uuid;
+}

--- a/tests/Unit/PlanGroups/PlanTest.php
+++ b/tests/Unit/PlanGroups/PlanTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use ChartMogul\Http\Client;
+use ChartMogul\PlanGroups\Plan;
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Response;
+
+class PlanGroupsPlanTest extends \PHPUnit\Framework\TestCase
+{
+    const ALL_PLAN_GROUPS_PLANS_JSON = '{
+    "plans": [
+      {
+        "name": "A Test Plan",
+        "uuid": "pl_2f7f4360-3633-0138-f01f-62b37fb4c770",
+        "data_source_uuid":"ds_424b9628-5405-11ea-ab18-e3a0f4f45097",
+        "interval_count":1,
+        "interval_unit":"month",
+        "external_id":"2f7f4360-3633-0138-f01f-62b37fb4c770"
+      },
+      {
+        "name":"Another Test Plan",
+        "uuid": "pl_3011ead0-3633-0138-f020-62b37fb4c770",
+        "data_source_uuid": "ds_424b9628-5405-11ea-ab18-e3a0f4f45097",
+        "interval_count": 1,
+        "interval_unit": "month",
+        "external_id": "3011ead0-3633-0138-f020-62b37fb4c770"
+      }
+    ],
+    "current_page": 1,
+    "total_pages": 1
+  }';
+
+    public function testAllPlanGroups()
+    {
+      $stream = Psr7\stream_for(PlanGroupsPlanTest::ALL_PLAN_GROUPS_PLANS_JSON);
+      $response = new Response(200, ['Content-Type' => 'application/json'], $stream);
+      $mockClient = new \Http\Mock\Client();
+      $mockClient->addResponse($response);
+
+      $cmClient = new Client(null, $mockClient);
+      $planGroupUuid = 'plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab';
+      $query = [
+        "plan_group_uuid" => $planGroupUuid,
+        "page" => 1,
+        "per_page" => 2
+      ];
+
+      $result = Plan::all($query, $cmClient);
+      $request = $mockClient->getRequests()[0];
+
+      $this->assertEquals("GET", $request->getMethod());
+      $uri = $request->getUri();
+      $this->assertEquals("/v1/plan_groups/$planGroupUuid/plans", $uri->getPath());
+      $this->assertEquals("page=1&per_page=2", $uri->getQuery());
+
+      $this->assertEquals(2, sizeof($result));
+      $this->assertTrue($result[0] instanceof ChartMogul\PlanGroups\Plan);
+      $this->assertEquals("pl_2f7f4360-3633-0138-f01f-62b37fb4c770", $result[0]->uuid);
+      $this->assertEquals("ds_424b9628-5405-11ea-ab18-e3a0f4f45097", $result[0]->data_source_uuid);
+      $this->assertEquals(1, $result->current_page);
+      $this->assertEquals(1, $result->total_pages);
+    }
+}

--- a/tests/Unit/PlanGroupsTest.php
+++ b/tests/Unit/PlanGroupsTest.php
@@ -1,0 +1,171 @@
+<?php
+
+use ChartMogul\Http\Client;
+use ChartMogul\PlanGroup;
+use ChartMogul\Exceptions\ChartMogulException;
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Response;
+use ChartMogul\Exceptions\NotFoundException;
+
+class PlanGroupTest extends \PHPUnit\Framework\TestCase
+{
+    const ALL_PLAN_GROUPS_JSON = '{
+      "plan_groups": [{
+        "name": "My plan group",
+        "uuid": "plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab",
+        "plans_count": 2
+      }],
+      "current_page": 2,
+      "total_pages": 3
+    }';
+    const RETRIEVE_PLAN_GROUP = '{
+      "name": "My plan group",
+      "uuid": "plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab",
+      "plans_count": 2
+    }';
+
+    public function testAllPlanGroups()
+    {
+      $stream = Psr7\stream_for(PlanGroupTest::ALL_PLAN_GROUPS_JSON);
+      $response = new Response(200, ['Content-Type' => 'application/json'], $stream);
+      $mockClient = new \Http\Mock\Client();
+      $mockClient->addResponse($response);
+
+      $cmClient = new Client(null, $mockClient);
+      $query = ["page" => 2, "per_page" => 1];
+
+      $result = PlanGroup::all($query, $cmClient);
+      $request = $mockClient->getRequests()[0];
+
+      $this->assertEquals("GET", $request->getMethod());
+      $uri = $request->getUri();
+      $this->assertEquals("page=2&per_page=1", $uri->getQuery());
+      $this->assertEquals("/v1/plan_groups", $uri->getPath());
+
+      $this->assertEquals(1, sizeof($result));
+      $this->assertTrue($result[0] instanceof PlanGroup);
+      $this->assertEquals("plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab", $result[0]->uuid);
+      $this->assertEquals(2, $result->current_page);
+      $this->assertEquals(3, $result->total_pages);
+    }
+
+    public function testDestroyPlanGroup()
+    {
+      $response = new Response(204);
+      $mockClient = new \Http\Mock\Client();
+      $mockClient->addResponse($response);
+
+      $cmClient = new Client(null, $mockClient);
+      $result = (new PlanGroup(["uuid" => "plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab"], $cmClient))->destroy();
+      $request = $mockClient->getRequests()[0];
+
+      $this->assertEquals("DELETE", $request->getMethod());
+      $uri = $request->getUri();
+      $this->assertEquals("", $uri->getQuery());
+      $this->assertEquals("/v1/plan_groups/plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab", $uri->getPath());
+    }
+
+    public function testDestroyPlanGroupNotFound()
+    {
+        $this->expectException(NotFoundException::class);
+        $response = new Response(404);
+        $mockClient = new \Http\Mock\Client();
+        $mockClient->addResponse($response);
+
+        $cmClient = new Client(null, $mockClient);
+        $result = (new PlanGroup(["uuid" => "plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab"], $cmClient))->destroy();
+    }
+
+    public function testRetrievePlanGroup()
+    {
+        $stream = Psr7\stream_for(PlanGroupTest::RETRIEVE_PLAN_GROUP);
+        $response = new Response(200, ['Content-Type' => 'application/json'], $stream);
+        $mockClient = new \Http\Mock\Client();
+        $mockClient->addResponse($response);
+
+        $uuid = 'plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab';
+
+        $cmClient = new Client(null, $mockClient);
+        $result = PlanGroup::retrieve($uuid, $cmClient);
+        $request = $mockClient->getRequests()[0];
+
+        $this->assertEquals("GET", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("", $uri->getQuery());
+        $this->assertEquals("/v1/plan_groups/".$uuid, $uri->getPath());
+
+        $this->assertTrue($result instanceof PlanGroup);
+        $this->assertEquals($uuid, $result->uuid);
+    }
+
+    public function testCreatePlanGroup()
+    {
+      $stream = Psr7\stream_for(PlanGroupTest::RETRIEVE_PLAN_GROUP);
+      $response = new Response(200, ['Content-Type' => 'application/json'], $stream);
+      $mockClient = new \Http\Mock\Client();
+      $mockClient->addResponse($response);
+      $plan_uuid_1 = 'pl_7e7c1bc7-50e0-447d-9750-8d66e9c0c702';
+      $plan_uuid_2 = 'pl_2d1ca933-8745-43d9-a836-85674597699c';
+
+
+      $cmClient = new Client(null, $mockClient);
+
+      $result = ChartMogul\PlanGroup::create([
+          "name" => "My Plan Group",
+          "plans" => [$plan_uuid_1, $plan_uuid_2],
+      ],
+      $cmClient
+      );
+
+      $request = $mockClient->getRequests()[0];
+
+      $this->assertEquals("POST", $request->getMethod());
+      $uri = $request->getUri();
+      $this->assertEquals("", $uri->getQuery());
+      $this->assertEquals("/v1/plan_groups", $uri->getPath());
+
+      $this->assertTrue($result instanceof PlanGroup);
+      $this->assertEquals("plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab", $result->uuid);
+    }
+
+    public function testUpdatePlanGroup()
+    {
+      $stream = Psr7\stream_for(PlanGroupTest::RETRIEVE_PLAN_GROUP);
+      $response = new Response(200, ['Content-Type' => 'application/json'], $stream);
+      $mockClient = new \Http\Mock\Client();
+      $mockClient->addResponse($response);
+
+      $uuid = 'plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab';
+
+      $cmClient = new Client(null, $mockClient);
+      $plan_group = PlanGroup::retrieve($uuid, $cmClient);
+
+      $stream = Psr7\stream_for(PlanGroupTest::RETRIEVE_PLAN_GROUP);
+      $response = new Response(200, ['Content-Type' => 'application/json'], $stream);
+      $mockClient = new \Http\Mock\Client();
+      $mockClient->addResponse($response);
+
+      $uuid = 'plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab';
+      $plan_uuid_1 = 'pl_7e7c1bc7-50e0-447d-9750-8d66e9c0c702';
+      $plan_uuid_2 = 'pl_2d1ca933-8745-43d9-a836-85674597699c';
+
+      $cmClient = new Client(null, $mockClient);
+      $result = PlanGroup::update(
+        ["plan_group_uuid" => $uuid],
+        [
+        "name" => "My plan group",
+        "plans" => [$plan_uuid_1, $plan_uuid_2]
+        ],
+        $cmClient
+      );
+
+      $request = $mockClient->getRequests()[0];
+      $this->assertEquals("PATCH", $request->getMethod());
+      $uri = $request->getUri();
+      $this->assertEquals("", $uri->getQuery());
+      $this->assertEquals("/v1/plan_groups/plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab", $uri->getPath());
+      $this->assertTrue($result instanceof PlanGroup);
+      $this->assertEquals($result->name, "My plan group");
+      $this->assertEquals($result->plans_count, 2);
+    }
+}


### PR DESCRIPTION
This allows you to carry out the following operations on plans groups:
1. create
2. retrieve
3. update
4. destroy 
5. list

Additionally, you can list all plans in a given plan group.
