### PR TITLE
Remove nullable Customer return type

### DIFF
--- a/src/Customer.php
+++ b/src/Customer.php
@@ -101,7 +101,7 @@ class Customer extends AbstractResource
      * @param string $externalId
      * @return Customer|null
      */
-    public static function findByExternalId($externalId): ?Customer
+    public static function findByExternalId($externalId)
     {
         if (gettype($externalId) == 'string') {
             $externalId = ['external_id' => $externalId];
@@ -113,7 +113,7 @@ class Customer extends AbstractResource
             return null;
         }
 
-        return $response->first();
+        return $response->first() || null;
     }
 
     /**


### PR DESCRIPTION
The introduction of a nullable Customer return type causes a regression because the return type was in fact either a Customer or a boolean (false)

```
Time: 4.05 seconds, Memory: 12.00 MB
There was 1 error:
1) CustomerTest::testSearchCustomerByExternalId
TypeError: Return value of ChartMogul\Customer::findByExternalId() must be an instance of ChartMogul\Customer or null, boolean returned
/src/src/Customer.php:116
/src/tests/Unit/CustomerTest.php:243
```

This PR:
1. removes the nullable Customer type return, 
2. returns either the Customer object or null