### PR TITLE
Bug Fix/use correct operator in findByExternalId

### DIFF
--- a/src/Customer.php
+++ b/src/Customer.php
@@ -113,7 +113,7 @@ class Customer extends AbstractResource
             return null;
         }
 
-        return $response->first() || null;
+        return $response->first() ?: null;
     }
 
     /**


### PR DESCRIPTION
https://github.com/chartmogul/chartmogul-php/pull/61 made a change to either return the first element of the collection customer or return null tho this introduces a bug because the || "or" operator was used and the collection was treated like a boolean value, meaning that this function returned either true if the customer exists or null.

I fixed this issue by using the correct operator, which is the Elvis operator (?:), this will evaluate if a value is false will return null otherwise will return the value "which is the customer in our case".