### PR TITLE
Add Account API endpoint[ch28502]

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,13 @@ ChartMogul\Metrics\Activities::all([
 ]);
 ```
 
+### Account
+
+**Retrieve Account Details**
+
+```php
+ChartMogul\Account::retrieve();
+```
 
 ### Exceptions
 

--- a/src/Account.php
+++ b/src/Account.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ChartMogul;
+
+use ChartMogul\Http\ClientInterface;
+use ChartMogul\Resource\AbstractResource;
+use ChartMogul\Service\ShowTrait;
+
+/**
+* @codeCoverageIgnore
+* @property-read string $name
+* @property-read string $currency
+* @property-read string $time_zone
+* @property-read string $week_start_on
+*/
+class Account extends AbstractResource
+{
+
+    use ShowTrait;
+
+    /**
+     * @ignore
+     */
+    const RESOURCE_PATH = '/v1/account';
+    /**
+     * @ignore
+     */
+    const RESOURCE_NAME = 'Account';
+    /**
+     * @ignore
+     */
+    const ROOT_KEY = 'account';
+
+    public $name;
+    public $currency;
+    public $time_zone;
+    public $week_start_on;
+}

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -30,7 +30,7 @@ class Client implements ClientInterface
     /**
     * @var string
     */
-    private $apiVersion = '1.0.0';
+    private $apiVersion = '1.1.0';
 
     /**
     * @var string

--- a/src/Service/RequestService.php
+++ b/src/Service/RequestService.php
@@ -136,13 +136,16 @@ class RequestService
             ->send($this->getResourcePath($obj->toArray()).'/'.$obj->uuid, 'DELETE');
         return true;
     }
-    
-    public function get($uuid)
+
+    public function get($uuid = null)
     {
         $class = $this->resourceClass;
         $response = $this->client
             ->setResourceKey($class::RESOURCE_NAME)
-            ->send($class::RESOURCE_PATH.'/'.$uuid, 'GET');
+            ->send(
+                $uuid ? $class::RESOURCE_PATH.'/'.$uuid : $class::RESOURCE_PATH,
+                'GET'
+            );
 
         return $class::fromArray($response, $this->client);
     }

--- a/src/Service/ShowTrait.php
+++ b/src/Service/ShowTrait.php
@@ -1,0 +1,23 @@
+<?php
+namespace ChartMogul\Service;
+
+use ChartMogul\Http\ClientInterface;
+
+/**
+* @codeCoverageIgnore
+*/
+trait ShowTrait
+{
+
+    /**
+     * Show details of current resource.
+     * @return resource
+     */
+
+    public static function retrieve(ClientInterface $client = null)
+    {
+        return (new RequestService($client))
+            ->setResourceClass(static::class)
+            ->get();
+    }
+}

--- a/tests/Unit/AccountTest.php
+++ b/tests/Unit/AccountTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace ChartMogul\Tests;
+
+use ChartMogul\Http\Client;
+use ChartMogul\Account;
+use ChartMogul\Exceptions\ChartMogulException;
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Response;
+use ChartMogul\Exceptions\NotFoundException;
+
+class AccountTest extends TestCase
+{
+  const RETRIEVE_ACCOUNT = '{
+    "name": "Example Test Company",
+    "currency": "EUR",
+    "time_zone": "Europe/Berlin",
+    "week_start_on": "sunday"
+  }';
+
+  public function testRetrieveAccount()
+  {
+      $stream = Psr7\stream_for(AccountTest::RETRIEVE_ACCOUNT);
+      list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+      $result = Account::retrieve($cmClient);
+      $request = $mockClient->getRequests()[0];
+
+      $this->assertEquals("GET", $request->getMethod());
+      $uri = $request->getUri();
+      $this->assertEquals("", $uri->getQuery());
+      $this->assertEquals("/v1/account", $uri->getPath());
+
+      $this->assertTrue($result instanceof Account);
+      $this->assertEquals($result->name, "Example Test Company");
+      $this->assertEquals($result->currency, "EUR");
+      $this->assertEquals($result->time_zone, "Europe/Berlin");
+      $this->assertEquals($result->week_start_on, "sunday");
+  }
+}

--- a/tests/Unit/Http/ClientTest.php
+++ b/tests/Unit/Http/ClientTest.php
@@ -35,7 +35,7 @@ class ClientTest extends TestCase
             ->setMethods(null)
             ->getMock();
 
-        $this->assertEquals("chartmogul-php/1.0.0/PHP-".PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION, $mock->getUserAgent());
+        $this->assertEquals("chartmogul-php/1.1.0/PHP-".PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION, $mock->getUserAgent());
     }
 
     public function testGetBasicAuthHeader()


### PR DESCRIPTION
Make current account details available via API calls:
- name
- currency
- time zone
- week start on

Find more information [here](https://www.notion.so/chartmogul/WIP-App-Make-account-details-available-via-API-calls-379e0e91d8d94a37ae04ffdfcf57c8c7) on Notion.

[https://app.clubhouse.io/chartmogul/story/28502/update-libraries-for-account-api-endpoints](https://app.clubhouse.io/chartmogul/story/28502/update-libraries-for-account-api-endpoints)