### PR TITLE
Implement async activities export [ch32346]

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,22 @@ ChartMogul\Metrics\Activities::all([
     'start-date' => '2020-06-02T00:00:00Z',
     'per-page' => 100
 ]);
+
+**Create an Activities Export**
+
+```php
+ChartMogul\Metrics\ActivitiesExport::create([
+    'start-date' => '2020-06-02T00:00:00Z',
+    'end-date' =>  '2021-06-02T00:00:00Z'
+    'type' => 'churn'
+]);
+```
+
+**Retrieve an Activities Export**
+
+```php
+$id = '7f554dba-4a41-4cb2-9790-2045e4c3a5b1';
+ChartMogul\Metrics\ActivitiesExport::retrieve($id);
 ```
 
 ### Account

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -30,7 +30,7 @@ class Client implements ClientInterface
     /**
     * @var string
     */
-    private $apiVersion = '4.0.0';
+    private $apiVersion = '4.1.0';
 
     /**
     * @var string

--- a/src/Metrics/ActivitiesExport.php
+++ b/src/Metrics/ActivitiesExport.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace ChartMogul\Metrics;
+
+use ChartMogul\Resource\AbstractResource;
+use ChartMogul\Http\ClientInterface;
+use ChartMogul\Service\CreateTrait;
+use ChartMogul\Service\GetTrait;
+
+/**
+ * @property-read string $id;
+ * @property-read string $status;
+ * @property-read string $file_url;
+ * @property-read string $params;
+ * @property-read string $expires_at;
+ * @property-read string $created_at;
+ */
+class ActivitiesExport extends AbstractResource
+{
+    use CreateTrait;
+    use GetTrait;
+
+    /**
+     * @ignore
+     */
+    public const RESOURCE_NAME = 'ActivitiesExport';
+    /**
+     * @ignore
+     */
+    public const RESOURCE_PATH = '/v1/activities_export';
+    public const RESOURCE_ID = 'activities_export_uuid';
+    public const ROOT_KEY = null;
+
+    protected $id;
+    protected $status;
+    protected $file_url;
+    protected $params;
+    protected $expires_at;
+    protected $created_at;
+
+    protected $activity_type;
+    protected $start_date;
+    protected $end_date;
+}

--- a/src/Metrics/ActivitiesExport.php
+++ b/src/Metrics/ActivitiesExport.php
@@ -11,7 +11,7 @@ use ChartMogul\Service\GetTrait;
  * @property-read string $id;
  * @property-read string $status;
  * @property-read string $file_url;
- * @property-read string $params;
+ * @property-read mixed $params;
  * @property-read string $expires_at;
  * @property-read string $created_at;
  */
@@ -38,7 +38,7 @@ class ActivitiesExport extends AbstractResource
     protected $expires_at;
     protected $created_at;
 
-    protected $activity_type;
+    protected $type;
     protected $start_date;
     protected $end_date;
 }

--- a/tests/Unit/Http/ClientTest.php
+++ b/tests/Unit/Http/ClientTest.php
@@ -10,7 +10,7 @@ use Http\Client\HttpClient;
 use Http\Discovery\MessageFactoryDiscovery;
 
 class ClientTest extends TestCase
-{ 
+{
     public function setUp(): void
     {
         parent::setUp();
@@ -35,7 +35,7 @@ class ClientTest extends TestCase
             ->setMethods(null)
             ->getMock();
 
-        $this->assertEquals("chartmogul-php/4.0.0/PHP-".PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION, $mock->getUserAgent());
+        $this->assertEquals("chartmogul-php/4.1.0/PHP-".PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION, $mock->getUserAgent());
     }
 
     public function testGetBasicAuthHeader()

--- a/tests/Unit/Metrics/ActivitiesExportTest.php
+++ b/tests/Unit/Metrics/ActivitiesExportTest.php
@@ -1,0 +1,86 @@
+<?php
+namespace ChartMogul\Tests;
+
+use ChartMogul\Http\Client;
+use ChartMogul\Metrics;
+use ChartMogul\Metrics\ActivitiesExport;
+use ChartMogul\Exceptions\ChartMogulException;
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Response;
+
+class ActivitiesExportTest extends TestCase
+{
+
+    const POST_JSON  = '{
+							      "id": "7f554dba-4a41-4cb2-9790-2045e4c3a5b1",
+							      "status": "pending",
+							      "file_url": null,
+							      "params": {
+							        "kind": "activities",
+							        "params": {
+							          "activity_type": "contraction",
+							          "start_date": "2020-01-01",
+							          "end_date": "2020-12-31"
+							        }
+							      },
+							      "expires_at": null,
+							      "created_at": "2021-07-12T14:46:56+00:00"
+							    }';
+
+    const GET_JSON = '{
+							      "id": "7f554dba-4a41-4cb2-9790-2045e4c3a5b1",
+							      "status": "succeeded",
+							      "file_url": "https://chartmogul-customer-export.s3.eu-west-1.amazonaws.com/activities-acme-corp-91e1ca88-d747-4e25-83d9-2b752033bdba.zip",
+							      "params": {
+							        "kind": "activities",
+							        "params": {
+							          "activity_type": "contraction",
+							          "start_date": "2020-01-01",
+							          "end_date": "2020-12-31"
+							        }
+							      },
+							      "expires_at": "2021-07-19T14:46:58+00:00",
+							      "created_at": "2021-07-12T14:46:56+00:00"
+							    }';
+
+
+    public function testActivitiesExportCreation()
+    {
+        $stream = Psr7\stream_for(ActivitiesExportTest::POST_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $result = ActivitiesExport::create(['type' => 'contraction', 'start_date' => '2020-01-01', 'end_date' => '2020-12-31'], $cmClient);
+        $request = $mockClient->getRequests()[0];
+
+        $this->assertEquals("POST", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/activities_export", $uri->getPath());
+
+        $this->assertTrue($result instanceof ActivitiesExport);
+        $this->assertEquals($result->id, "7f554dba-4a41-4cb2-9790-2045e4c3a5b1");
+        $this->assertEquals($result->status, "pending");
+        $this->assertEquals($result->file_url, null);
+
+    }
+
+    public function testActivitiesExportRetrieval()
+    {
+        $stream = Psr7\stream_for(ActivitiesExportTest::GET_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $id = '7f554dba-4a41-4cb2-9790-2045e4c3a5b1';
+
+        $result = ActivitiesExport::retrieve($id, $cmClient);
+        $request = $mockClient->getRequests()[0];
+
+        $this->assertEquals("GET", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/activities_export/7f554dba-4a41-4cb2-9790-2045e4c3a5b1", $uri->getPath());
+
+        $this->assertTrue($result instanceof ActivitiesExport);
+        $this->assertEquals($result->id, "7f554dba-4a41-4cb2-9790-2045e4c3a5b1");
+        $this->assertEquals($result->status, "succeeded");
+        $this->assertEquals($result->file_url, "https://chartmogul-customer-export.s3.eu-west-1.amazonaws.com/activities-acme-corp-91e1ca88-d747-4e25-83d9-2b752033bdba.zip");
+
+    }
+}

--- a/tests/Unit/Metrics/ActivitiesExportTest.php
+++ b/tests/Unit/Metrics/ActivitiesExportTest.php
@@ -49,7 +49,7 @@ class ActivitiesExportTest extends TestCase
         $stream = Psr7\stream_for(ActivitiesExportTest::POST_JSON);
         list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
 
-        $result = ActivitiesExport::create(['type' => 'contraction', 'start_date' => '2020-01-01', 'end_date' => '2020-12-31'], $cmClient);
+        $result = ActivitiesExport::create(['type' => 'contraction', 'start-date' => '2020-01-01', 'end-date' => '2020-12-31'], $cmClient);
         $request = $mockClient->getRequests()[0];
 
         $this->assertEquals("POST", $request->getMethod());


### PR DESCRIPTION
This PR implements support for creating and retrieving async activities exports:

**Create an Activities Export**

```php
ChartMogul\Metrics\ActivitiesExport::create([
    'start-date' => '2020-06-02T00:00:00Z',
    'end-date' =>  '2021-06-02T00:00:00Z'
    'type' => 'churn'
]);
```

**Retrieve an Activities Export**

```php
$id = '7f554dba-4a41-4cb2-9790-2045e4c3a5b1';
ChartMogul\Metrics\ActivitiesExport::retrieve($id);
```

It also bumps the version to 4.1.0