### PR TITLE
Update of versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.4', '8.0', '8.1']
         phpunit-versions: ['latest']
-        include:
-        - php-versions: '7.2'
-          phpunit-versions: '8.5.13'
-        - php-versions: '7.1'
-          phpunit-versions: '7.5.20'
     steps:
       - uses: actions/checkout@v2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,10 @@ RUN mv composer.phar /usr/local/bin/composer
 RUN chmod a+x /usr/local/bin/composer
 RUN apt-get update && apt-get  install -y git unzip
 ARG VERSION
-RUN if [ "$VERSION" = "7.1" ]; then \
-    composer global require phpunit/phpunit:^7; \
-    elif [ "$VERSION" = "7.2" ]; then \
+RUN if [ "$VERSION" = "7.4" ]; then \
     composer global require phpunit/phpunit:^8; else \
     composer global require phpunit/phpunit:^9; fi
-RUN if [ "$VERSION" = "8.0" ]; then \
-    pecl install xdebug-3.0.4;  else \
-    pecl install xdebug-2.7.2; fi
+RUN pecl install xdebug-3.1.5
 RUN docker-php-ext-enable xdebug
 ENV PATH="${PATH}:/root/.composer/vendor/bin"
 COPY php.ini /usr/local/etc/php/

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,11 @@
-RUNNER=docker run -it --rm --workdir "/src" -v "$(PWD):/src" -v "$(HOME)/.composer/cache:/root/.composer/cache" chartmogulphp73 /bin/bash -c
+RUNNER=docker run -it --rm --workdir "/src" -v "$(PWD):/src" -v "$(HOME)/.composer/cache:/root/.composer/cache" chartmogulphp74 /bin/bash -c
 
 .PHONY: build composer php
 
 build:
-	@docker build --build-arg VERSION=7.1 --tag=chartmogulphp71 .
-	@docker build --build-arg VERSION=7.2 --tag=chartmogulphp72 .
-	@docker build --build-arg VERSION=7.3 --tag=chartmogulphp73 .
+	@docker build --build-arg VERSION=7.4 --tag=chartmogulphp74 .
 	@docker build --build-arg VERSION=8.0 --tag=chartmogulphp80 .
+	@docker build --build-arg VERSION=8.1 --tag=chartmogulphp81 .
 composer:
 	$(RUNNER) "composer $(filter-out $@,$(MAKECMDGOALS))"
 dependencies:

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@
 
 This library requires php 5.5 or above.
 
-For older php versions (`< 7.1`) use `1.x.x` releases of this library.
+For older php versions (`< 7.4`) use `1.x.x` releases of this library.
 
-For php version `>=7.1` use the latest releases (`4.x.x`) of the library
+For php version `>=7.4` use the latest releases (`5.x.x`) of the library
 
 
 The library doesn't depend on any concrete HTTP client libraries. Follow the instructions [here](http://docs.php-http.org/en/latest/httplug/users.html) to find out how to include a HTTP client.
@@ -41,7 +41,7 @@ The library doesn't depend on any concrete HTTP client libraries. Follow the ins
 Here's an example with `Guzzle HTTP client`:
 
 ```sh
-composer require chartmogul/chartmogul-php:^4.0 php-http/guzzle6-adapter:^2.0.1 http-interop/http-factory-guzzle:^1.0
+composer require chartmogul/chartmogul-php:^5.0 php-http/guzzle6-adapter:^2.0.1 http-interop/http-factory-guzzle:^1.0
 ```
 
 ## Configuration

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "php": "^7.1 | ^8.0",
+        "php": ">=7.1",
         "psr/http-message": "^1.0",
         "psr/http-client-implementation": "^1.0",
         "doctrine/collections": "^1.6",


### PR DESCRIPTION
Updating docs.
Also, added a 5.0.1 release on Github.
PHP 7.4 is the last supported branch on 7.x [(for 1 month more)](https://www.php.net/supported-versions.php)
PHP 8.1 is the current version.
`xdebug` actually supports [all relevant versions in 3.1.x](https://xdebug.org/docs/compat#f1).

Tested by running `make` locally.