### PR TITLE
Add support for doctrine collection 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['7.4', '8.0', '8.1']
-        phpunit-versions: ['latest']
+        phpunit-versions: ['9.6']
     steps:
       - uses: actions/checkout@v2
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php": ">=7.1",
         "psr/http-message": "^1.0",
         "psr/http-client-implementation": "^1.0",
-        "doctrine/collections": "^1.6",
+        "doctrine/collections": "^1.6 || ^2.0",
         "stechstudio/backoff": "^1.0",
         "php-http/discovery": "^1.13"
     },

--- a/tests/Unit/Http/ClientTest.php
+++ b/tests/Unit/Http/ClientTest.php
@@ -32,6 +32,7 @@ class ClientTest extends TestCase
     {
         $mock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
+            ->onlyMethods([])
             ->getMock();
 
         $this->assertEquals("chartmogul-php/5.0.1/PHP-".PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION, $mock->getUserAgent());
@@ -57,6 +58,7 @@ class ClientTest extends TestCase
     {
         $mock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
+            ->onlyMethods([])
             ->getMock();
 
         $res = MessageFactoryDiscovery::find()->createResponse(
@@ -89,6 +91,7 @@ class ClientTest extends TestCase
         $this->expectException($exception);
         $mock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
+            ->onlyMethods([])
             ->getMock();
 
         $res = MessageFactoryDiscovery::find()->createResponse(

--- a/tests/Unit/Http/ClientTest.php
+++ b/tests/Unit/Http/ClientTest.php
@@ -32,7 +32,6 @@ class ClientTest extends TestCase
     {
         $mock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(null)
             ->getMock();
 
         $this->assertEquals("chartmogul-php/5.0.1/PHP-".PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION, $mock->getUserAgent());
@@ -58,7 +57,6 @@ class ClientTest extends TestCase
     {
         $mock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(null)
             ->getMock();
 
         $res = MessageFactoryDiscovery::find()->createResponse(
@@ -71,7 +69,7 @@ class ClientTest extends TestCase
         $this->assertEquals($data, ['result' => 'json']);
     }
 
-    public function provider()
+    public static function provider()
     {
         return array(
             array(200, \ChartMogul\Exceptions\ChartMogulException::class),
@@ -91,7 +89,6 @@ class ClientTest extends TestCase
         $this->expectException($exception);
         $mock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethods(null)
             ->getMock();
 
         $res = MessageFactoryDiscovery::find()->createResponse(
@@ -103,7 +100,7 @@ class ClientTest extends TestCase
         $mock->handleResponse($res);
     }
 
-    public function providerSend()
+    public static function providerSend()
     {
         return [
             [

--- a/tests/Unit/Resources/AbstractModelTest.php
+++ b/tests/Unit/Resources/AbstractModelTest.php
@@ -23,6 +23,7 @@ class AbstractModelTest extends \PHPUnit\Framework\TestCase
     {
         $mock = $this->getMockBuilder(AbstractModel::class)
             ->setConstructorArgs([$in])
+            ->onlyMethods([])
             ->getMock();
 
         $output = $mock->toArray();

--- a/tests/Unit/Resources/AbstractModelTest.php
+++ b/tests/Unit/Resources/AbstractModelTest.php
@@ -7,7 +7,7 @@ class AbstractModelTest extends \PHPUnit\Framework\TestCase
 
 
 
-    public function provider()
+    public static function provider()
     {
         return [
             [ ['a' => 'b'], ['a' => 'b'] ],
@@ -23,7 +23,6 @@ class AbstractModelTest extends \PHPUnit\Framework\TestCase
     {
         $mock = $this->getMockBuilder(AbstractModel::class)
             ->setConstructorArgs([$in])
-            ->setMethods(null)
             ->getMock();
 
         $output = $mock->toArray();

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -16,7 +16,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
 
     protected function getMockClient($retries, $statuses, $stream = null, $exceptions = []){
         $mock = $this->getMockBuilder(Client::class)
-            ->setMethods(['getBasicAuthHeader', 'getUserAgent'])
+            ->onlyMethods(['getBasicAuthHeader', 'getUserAgent'])
             ->getMock();
 
         $mock->expects($this->once())


### PR DESCRIPTION
HI @pkopac @sbrych 

This PR add support for doctrine collection 2.

The new major add typehint and some method to the Collection interface but since this lib is only used to do
```
class Foo extends ArrayCollection
```
or
```
new ArrayCollection()
```
or 
```
if ($foo instanceof ArrayCollection)
```

There is nothing to change in the code.