### PR TITLE
Add missing property in MRR

### DIFF
--- a/src/Metrics/MRR.php
+++ b/src/Metrics/MRR.php
@@ -7,6 +7,7 @@ use ChartMogul\Resource\AbstractModel;
 /**
  * @property-read string $date;
  * @property-read int $mrr;
+ * @property-read string $percentage_change;
  * @property-read int $mrr_new_business;
  * @property-read int $mrr_expansion;
  * @property-read int $mrr_contraction;
@@ -17,6 +18,7 @@ class MRR extends AbstractModel
 {
     protected $date;
     protected $mrr;
+    protected $percentage_change;
 
     protected $mrr_new_business;
 


### PR DESCRIPTION
Hi @pkopac @sbrych,

I received tons of deprecations:
```
Deprecated: Creation of dynamic property ChartMogul\Metrics\MRR::$percentage_change is deprecated
```

According to the API reference the property `$percentage_change` exists
https://dev.chartmogul.com/reference/retrieve-mrr
So I added it to the class. It would be great if you have time to merge and release this. :)

I dunno if it was a miss or if the data was recently added to the API.
But if you're regularly adding new value in API response, you might want to add the `#[AllowDynamicProperties]` to the `AbstractModel` class in order to avoid any deprecations in the futur.