### PR TITLE
Allow installation of psr/http-message v2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "php": ">=7.1",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "psr/http-client-implementation": "^1.0",
         "doctrine/collections": "^1.6 || ^2.0",
         "stechstudio/backoff": "^1.0",


### PR DESCRIPTION
The only difference between v1 & v2 is adding types, see https://www.php-fig.org/psr/psr-7/meta/#72-type-additions

I haven't tested it yet, since we have some other dependencies stuck on v1.