### PR TITLE
support cursor based pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [5.1.3] - 2023-10-03
+
+### Added
+- Support for cursor based pagination (#114)
+- Linted the project with phpcs and phpcbf (#114)
+
 ## [5.1.2] - 2023-09-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ $plan_group_plans = ChartMogul\PlanGroups\Plan::all(
 $plan = ChartMogul\Plan::all()->first();
 $cus = ChartMogul\Customer::all()->first();
 
-$line_itme_1 = new ChartMogul\LineItems\Subscription([
+$line_item_1 = new ChartMogul\LineItems\Subscription([
     'subscription_external_id' => "sub_0001",
     'subscription_set_external_id' => 'set_0001',
     'plan_uuid' =>  $plan->uuid,
@@ -534,7 +534,7 @@ $line_itme_1 = new ChartMogul\LineItems\Subscription([
     'discount_description' => "5 EUR"
 ]);
 
-$line_itme_2 = new ChartMogul\LineItems\OneTime([
+$line_item_2 = new ChartMogul\LineItems\OneTime([
     "description" => "Setup Fees",
     "amount_in_cents" => 2500,
     "quantity" => 1,
@@ -555,7 +555,7 @@ $invoice = new ChartMogul\Invoice([
     'date' =>  "2015-11-01 00:00:00",
     'currency' => 'USD',
     'due_date' => "2015-11-15 00:00:00",
-    'line_items' => [$line_itme_1, $line_itme_2],
+    'line_items' => [$line_item_1, $line_item_2],
     'transactions' => [$transaction]
 ]);
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,9 @@
         "guzzlehttp/psr7": "^1.0",
         "http-interop/http-factory-guzzle": "^1.0",
         "php-vcr/php-vcr": "^1.5",
-        "php-http/curl-client": "^2.2"
+        "php-http/curl-client": "^2.2",
+        "squizlabs/php_codesniffer": "*",
+        "friendsofphp/php-cs-fixer": "^3.34"
     },
     "config": {
         "allow-plugins": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,3 +4,4 @@ parameters:
    - src
   ignoreErrors:
    - '#Unsafe usage of new static\(\).#'
+  treatPhpDocTypesAsCertain: false

--- a/src/Account.php
+++ b/src/Account.php
@@ -7,12 +7,12 @@ use ChartMogul\Resource\AbstractResource;
 use ChartMogul\Service\ShowTrait;
 
 /**
-* @codeCoverageIgnore
-* @property-read string $name
-* @property-read string $currency
-* @property-read string $time_zone
-* @property-read string $week_start_on
-*/
+ * @codeCoverageIgnore
+ * @property-read      string $name
+ * @property-read      string $currency
+ * @property-read      string $time_zone
+ * @property-read      string $week_start_on
+ */
 class Account extends AbstractResource
 {
     use ShowTrait;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -8,7 +8,7 @@ namespace ChartMogul;
  */
 class Configuration
 {
-	const DEFAULT_MAX_RETRIES = 20;
+    public const DEFAULT_MAX_RETRIES = 20;
 
     /**
      * @var null|Configuration
@@ -27,6 +27,7 @@ class Configuration
 
     /**
      * Creates new config object from apiKey
+     *
      * @param string $apiKey
      */
     public function __construct($apiKey = '', $retries = self::DEFAULT_MAX_RETRIES)
@@ -37,6 +38,7 @@ class Configuration
 
     /**
      * Get Api Key
+     *
      * @return string
      */
     public function getApiKey()
@@ -46,7 +48,8 @@ class Configuration
 
     /**
      * Set Api Key
-     * @param string $apiKey
+     *
+     * @param  string $apiKey
      * @return self
      */
     public function setApiKey($apiKey)
@@ -57,6 +60,7 @@ class Configuration
 
     /**
      * Get retries
+     *
      * @return int
      */
     public function getRetries()
@@ -66,7 +70,8 @@ class Configuration
 
     /**
      * Set max retries
-     * @param int $retries
+     *
+     * @param  int $retries
      * @return self
      */
     public function setRetries($retries)
@@ -77,7 +82,8 @@ class Configuration
 
     /**
      * Set Default Config object. Default config object is used when no config object is passed during resource call
-     * @return  Configuration
+     *
+     * @return Configuration
      */
     public static function getDefaultConfiguration()
     {
@@ -89,8 +95,9 @@ class Configuration
 
     /**
      * Get the default config object.
-     * @param Configuration $config
-     * @return  Configuration
+     *
+     * @param  Configuration $config
+     * @return Configuration
      */
     public static function setDefaultConfiguration(Configuration $config)
     {

--- a/src/Contact.php
+++ b/src/Contact.php
@@ -26,7 +26,6 @@ use ChartMogul\Service\GetTrait;
  * @property-read string $linked_in
  * @property-read string $twitter
  * @property-read string $custom
-
  */
 class Contact extends AbstractResource
 {
@@ -64,6 +63,7 @@ class Contact extends AbstractResource
 
     /**
      * Merge Contacts
+     *
      * @param  string               $into
      * @param  string               $from
      * @param  ClientInterface|null $client
@@ -81,16 +81,21 @@ class Contact extends AbstractResource
     /**
      * Overrides fromArray so that it will return a collection with cursor instead.
      *
-     * @param array $data
-     * @param ClientInterface|null $client
+     * @param  array                $data
+     * @param  ClientInterface|null $client
      * @return CollectionWithCursor|static
      */
     public static function fromArray(array $data, ClientInterface $client = null)
     {
         if (isset($data[static::ROOT_KEY])) {
-            $array = new CollectionWithCursor(array_map(function ($data) use ($client) {
-                return static::fromArray($data, $client);
-            }, $data[static::ROOT_KEY]));
+            $array = new CollectionWithCursor(
+                array_map(
+                    function ($data) use ($client) {
+                        return static::fromArray($data, $client);
+                    },
+                    $data[static::ROOT_KEY]
+                )
+            );
 
             if (isset($data["cursor"])) {
                 $array->cursor = $data["cursor"];

--- a/src/Customer.php
+++ b/src/Customer.php
@@ -29,7 +29,6 @@ use ChartMogul\Service\GetTrait;
  * @property-read string $billing_system_type
  * @property-read string $currency
  * @property-read string $currency_sign
-
  */
 class Customer extends AbstractResource
 {
@@ -84,6 +83,7 @@ class Customer extends AbstractResource
 
     /**
      * Get Customer Tags
+     *
      * @return array
      */
     public function tags()
@@ -93,6 +93,7 @@ class Customer extends AbstractResource
 
     /**
      * Get Customer Custom Attributes
+     *
      * @return array
      */
     public function customAttributes()
@@ -102,7 +103,8 @@ class Customer extends AbstractResource
 
     /**
      * Find a Customer by External ID. Returns only first result!
-     * @param string $externalId
+     *
+     * @param  string               $externalId
      * @param  ClientInterface|null $client
      * @return Customer|null
      */
@@ -114,8 +116,7 @@ class Customer extends AbstractResource
 
         $response = self::all($externalId, $client);
 
-        if (
-            $response instanceof Collection
+        if ($response instanceof Collection
             && !$response->isEmpty()
         ) {
             return $response->first();
@@ -126,7 +127,8 @@ class Customer extends AbstractResource
 
     /**
      * Search for Customers
-     * @param  string                $email
+     *
+     * @param  string               $email
      * @param  ClientInterface|null $client
      * @return Collection|static
      */
@@ -142,8 +144,9 @@ class Customer extends AbstractResource
 
     /**
      * Merge Customers
-     * @param  array               $from
-     * @param  array               $into
+     *
+     * @param  array                $from
+     * @param  array                $into
      * @param  ClientInterface|null $client
      * @return bool
      */
@@ -152,15 +155,20 @@ class Customer extends AbstractResource
         (new static([], $client))
             ->getClient()
             ->setResourcekey(static::class)
-            ->send('/v1/customers/merges', 'POST', [
+            ->send(
+                '/v1/customers/merges',
+                'POST',
+                [
                 'from' => $from,
                 'into' => $into
-            ]);
+                ]
+            );
         return true;
     }
 
     /**
      * Connect Subscriptions
+     *
      * @param  string               $customerUUID
      * @param  array                $data
      * @param  ClientInterface|null $client
@@ -178,15 +186,20 @@ class Customer extends AbstractResource
 
     /**
      * Add tags to a customer
-     * @param mixed $tags,...
-     * @return  array
+     *
+     * @param  mixed $tags,...
+     * @return array
      */
     public function addTags($tags)
     {
         $result = $this->getClient()
-            ->send('/v1/customers/'.$this->uuid.'/attributes/tags', 'POST', [
+            ->send(
+                '/v1/customers/'.$this->uuid.'/attributes/tags',
+                'POST',
+                [
                 'tags' => func_get_args()
-            ]);
+                ]
+            );
 
         $this->attributes['tags'] = $result['tags'];
         return $result['tags'];
@@ -195,15 +208,20 @@ class Customer extends AbstractResource
 
     /**
      * Remove Tags from a Customer
-     * @param mixed $tags,...
+     *
+     * @param  mixed $tags,...
      * @return array
      */
     public function removeTags($tags)
     {
         $result = $this->getClient()
-            ->send('/v1/customers/'.$this->uuid.'/attributes/tags', 'DELETE', [
+            ->send(
+                '/v1/customers/'.$this->uuid.'/attributes/tags',
+                'DELETE',
+                [
                 'tags' => func_get_args()
-            ]);
+                ]
+            );
 
         $this->attributes['tags'] = $result['tags'];
         return $result['tags'];
@@ -211,15 +229,20 @@ class Customer extends AbstractResource
 
     /**
      * Add Custom Attributes to a Customer
-     * @param mixed $custom,...
+     *
+     * @param  mixed $custom,...
      * @return array
      */
     public function addCustomAttributes($custom)
     {
         $result = $this->getClient()
-            ->send('/v1/customers/'.$this->uuid.'/attributes/custom', 'POST', [
+            ->send(
+                '/v1/customers/'.$this->uuid.'/attributes/custom',
+                'POST',
+                [
                 'custom' => func_get_args()
-            ]);
+                ]
+            );
 
         $this->attributes['custom'] = $result['custom'];
         return $result['custom'];
@@ -228,15 +251,20 @@ class Customer extends AbstractResource
 
     /**
      * Remove Custom Attributes from a Customer
-     * @param mixed $custom,...
+     *
+     * @param  mixed $custom,...
      * @return array
      */
     public function removeCustomAttributes($custom)
     {
         $result = $this->getClient()
-            ->send('/v1/customers/'.$this->uuid.'/attributes/custom', 'DELETE', [
+            ->send(
+                '/v1/customers/'.$this->uuid.'/attributes/custom',
+                'DELETE',
+                [
                 'custom' => func_get_args()
-            ]);
+                ]
+            );
 
         $this->attributes['custom'] = $result['custom'];
         return $result['custom'];
@@ -244,7 +272,8 @@ class Customer extends AbstractResource
 
     /**
      * Update Custom Attributes of a Customer
-     * @param mixed $custom,...
+     *
+     * @param  mixed $custom,...
      * @return array
      */
     public function updateCustomAttributes($custom)
@@ -254,9 +283,13 @@ class Customer extends AbstractResource
             $data = array_merge($data, $value);
         }
         $result = $this->getClient()
-            ->send('/v1/customers/'.$this->uuid.'/attributes/custom', 'PUT', [
+            ->send(
+                '/v1/customers/'.$this->uuid.'/attributes/custom',
+                'PUT',
+                [
                 'custom' => $data
-            ]);
+                ]
+            );
 
         $this->attributes['custom'] = $result['custom'];
         return $result['custom'];
@@ -264,8 +297,9 @@ class Customer extends AbstractResource
 
     /**
      * Find a Customer Subscriptions
-     * @param  array  $options
-     * @return Collection | Customer
+     *
+     * @param      array $options
+     * @return     Collection | Customer
      * @deprecated Use Import\Subscription.
      */
     public function subscriptions(array $options = [])
@@ -279,8 +313,9 @@ class Customer extends AbstractResource
 
     /**
      * Find customer's invoices
-     * @param  array  $options
-     * @return Collection | Customer
+     *
+     * @param      array $options
+     * @return     Collection | Customer
      * @deprecated Use Import\CustomerInvoices.
      */
     public function invoices(array $options = [])
@@ -294,7 +329,8 @@ class Customer extends AbstractResource
 
     /**
      * Find all contacts in a customer
-     * @param  array  $options
+     *
+     * @param  array $options
      * @return CollectionWithCursor
      */
     public function contacts(array $options = [])
@@ -307,7 +343,8 @@ class Customer extends AbstractResource
 
     /**
      * Creates a contact from the customer.
-     * @param  array  $data
+     *
+     * @param  array $data
      * @return Contact
      */
     public function createContact(array $data = [])

--- a/src/Customers.php
+++ b/src/Customers.php
@@ -42,6 +42,7 @@ class Customers extends AbstractResource
 
     /**
      * Constructor
+     *
      * @param array                $attr
      * @param ClientInterface|null $client
      */
@@ -54,9 +55,10 @@ class Customers extends AbstractResource
 
     /**
      * Search for Customers
-     * @param  string                $email
-     * @param  ClientInterface|null $client
-     * @return Collection|static
+     *
+     * @param      string               $email
+     * @param      ClientInterface|null $client
+     * @return     Collection|static
      * @deprecated Use Customer.
      */
     public static function search($email, ClientInterface $client = null)

--- a/src/DataSource.php
+++ b/src/DataSource.php
@@ -10,10 +10,10 @@ use ChartMogul\Service\GetTrait;
 
 /**
  * @codeCoverageIgnore
- * @property-read string $uuid
- * @property-read string $status
- * @property-read string $created_at
- * @property-read string $system
+ * @property-read      string $uuid
+ * @property-read      string $status
+ * @property-read      string $created_at
+ * @property-read      string $system
  */
 class DataSource extends AbstractResource
 {

--- a/src/Exceptions/ChartMogulException.php
+++ b/src/Exceptions/ChartMogulException.php
@@ -23,9 +23,10 @@ class ChartMogulException extends \RuntimeException implements ResponseException
     /**
      * ChartMogulException
      * You can match against subclasses or parsed response.
-     * @param string $message Exception message
-     * @param ResponseInterface|null $response  ResponseInterface object
-     * @param \Exception|null $previous
+     *
+     * @param string                 $message  Exception message
+     * @param ResponseInterface|null $response ResponseInterface object
+     * @param \Exception|null        $previous
      */
     public function __construct($message, ResponseInterface $response = null, \Exception $previous = null)
     {

--- a/src/Exceptions/ForbiddenException.php
+++ b/src/Exceptions/ForbiddenException.php
@@ -4,6 +4,7 @@ namespace ChartMogul\Exceptions;
 
 /**
  * ForbiddenException
+ *
  * @codeCoverageIgnore
  */
 class ForbiddenException extends ChartMogulException

--- a/src/Exceptions/NotAllowedException.php
+++ b/src/Exceptions/NotAllowedException.php
@@ -4,6 +4,7 @@ namespace ChartMogul\Exceptions;
 
 /**
  * NotAllowedException
+ *
  * @codeCoverageIgnore
  */
 class NotAllowedException extends ChartMogulException

--- a/src/Exceptions/NotFoundException.php
+++ b/src/Exceptions/NotFoundException.php
@@ -4,6 +4,7 @@ namespace ChartMogul\Exceptions;
 
 /**
  * NotFoundException
+ *
  * @codeCoverageIgnore
  */
 class NotFoundException extends ChartMogulException

--- a/src/Exceptions/ResourceInvalidException.php
+++ b/src/Exceptions/ResourceInvalidException.php
@@ -4,6 +4,7 @@ namespace ChartMogul\Exceptions;
 
 /**
  * ResourceInvalidException
+ *
  * @codeCoverageIgnore
  */
 class ResourceInvalidException extends ChartMogulException

--- a/src/Exceptions/ResponseException.php
+++ b/src/Exceptions/ResponseException.php
@@ -4,18 +4,21 @@ namespace ChartMogul\Exceptions;
 
 /**
  * ResponseException Interface
+ *
  * @codeCoverageIgnore
  */
 interface ResponseException
 {
     /**
      * GET HTTP Status Code
+     *
      * @return int
      */
     public function getStatusCode();
 
     /**
      * Get HTTP response
+     *
      * @return string|array
      */
     public function getResponse();

--- a/src/Exceptions/SchemaInvalidException.php
+++ b/src/Exceptions/SchemaInvalidException.php
@@ -4,6 +4,7 @@ namespace ChartMogul\Exceptions;
 
 /**
  * SchemaInvalidException Interface
+ *
  * @codeCoverageIgnore
  */
 class SchemaInvalidException extends ChartMogulException

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -13,39 +13,39 @@ use Http\Discovery\Psr17FactoryDiscovery;
 class Client implements ClientInterface
 {
     /**
-    * @var HttpClient
-    */
+     * @var HttpClient
+     */
     private $client;
 
     /**
-    * @var Configuration
-    */
+     * @var Configuration
+     */
     private $config;
 
     /**
-    * @var string
-    */
+     * @var string
+     */
     private $resourceKey = 'resource';
 
     /**
-    * @var string
-    */
-    private $apiVersion = '5.1.2';
+     * @var string
+     */
+    private $apiVersion = '5.1.3';
 
     /**
-    * @var string
-    */
+     * @var string
+     */
     private $apiBase = 'https://api.chartmogul.com';
 
     /**
-    * @var RequestFactoryInterface
-    */
+     * @var RequestFactoryInterface
+     */
     private $requestFactory;
 
     /**
-     * @param Configuration|null $config Configuration Object
-     * @param HttpClient|null $client psr/http-client-implementaion object
-     * @param RequestFactoryInterface|null $requestFactory
+     * @param              Configuration|null           $config         Configuration Object
+     * @param              HttpClient|null              $client         psr/http-client-implementaion object
+     * @param              RequestFactoryInterface|null $requestFactory
      * @codeCoverageIgnore
      */
     public function __construct(
@@ -60,7 +60,7 @@ class Client implements ClientInterface
 
 
     /**
-     * @return Configuration
+     * @return             Configuration
      * @codeCoverageIgnore
      */
     public function getConfiguration()
@@ -69,7 +69,7 @@ class Client implements ClientInterface
     }
 
     /**
-     * @param Configuration $config Set config
+     * @param              Configuration $config Set config
      * @codeCoverageIgnore
      */
     public function setConfiguration(Configuration $config)
@@ -79,8 +79,8 @@ class Client implements ClientInterface
     }
 
     /**
-     * @param HttpClient $client
-     * @return self
+     * @param              HttpClient $client
+     * @return             self
      * @codeCoverageIgnore
      */
     public function setHttpClient(HttpClient $client)
@@ -90,7 +90,7 @@ class Client implements ClientInterface
     }
 
     /**
-     * @return HttpClient
+     * @return             HttpClient
      * @codeCoverageIgnore
      */
     public function getHttpClient()
@@ -99,8 +99,8 @@ class Client implements ClientInterface
     }
 
     /**
-    * @codeCoverageIgnore
-    */
+     * @codeCoverageIgnore
+     */
     public function setResourceKey($key)
     {
         $this->resourceKey = $key;
@@ -108,24 +108,24 @@ class Client implements ClientInterface
     }
 
     /**
-    * @codeCoverageIgnore
-    */
+     * @codeCoverageIgnore
+     */
     public function getResourceKey()
     {
         return $this->resourceKey;
     }
 
     /**
-    * @codeCoverageIgnore
-    */
+     * @codeCoverageIgnore
+     */
     public function getApiVersion()
     {
         return $this->apiVersion;
     }
 
     /**
-    * @codeCoverageIgnore
-    */
+     * @codeCoverageIgnore
+     */
     public function getApiBase()
     {
         return $this->apiBase;
@@ -153,9 +153,11 @@ class Client implements ClientInterface
     protected function sendWithRetry(RequestInterface $request)
     {
         $backoff = new Retry($this->config->getRetries());
-        $response =  $backoff->retry(function () use ($request) {
-            return $this->client->sendRequest($request);
-        });
+        $response =  $backoff->retry(
+            function () use ($request) {
+                return $this->client->sendRequest($request);
+            }
+        );
         return $this->handleResponse($response);
     }
 
@@ -184,7 +186,7 @@ class Client implements ClientInterface
     }
 
     /**
-     * @param ResponseInterface $response
+     * @param  ResponseInterface $response
      * @throws \ChartMogul\Exceptions\ChartMogulException
      * @return array
      */

--- a/src/Http/ClientInterface.php
+++ b/src/Http/ClientInterface.php
@@ -6,8 +6,8 @@ use ChartMogul\Configuration;
 use Psr\Http\Client\ClientInterface as HttpClient;
 
 /**
-* @codeCoverageIgnore
-*/
+ * @codeCoverageIgnore
+ */
 interface ClientInterface
 {
     public function getConfiguration();

--- a/src/Http/Retry.php
+++ b/src/Http/Retry.php
@@ -44,7 +44,7 @@ class Retry
         if ($this->retries === 0) {
             return $callback();
         }
-        $backoff = new Backoff($this->retries, new ExponentialStrategy(), 60*1000, true);
+        $backoff = new Backoff($this->retries, new ExponentialStrategy(), 60 * 1000, true);
         $backoff->setDecider($this);
         return $backoff->run($callback);
     }

--- a/src/Import/LineItems/AbstractLineItem.php
+++ b/src/Import/LineItems/AbstractLineItem.php
@@ -3,9 +3,9 @@
 namespace ChartMogul\Import\LineItems;
 
 /**
-* @codeCoverageIgnore
-* @deprecated
-*/
+ * @codeCoverageIgnore
+ * @deprecated
+ */
 abstract class AbstractLineItem extends \ChartMogul\LineItems\AbstractLineItem
 {
 }

--- a/src/Import/LineItems/OneTime.php
+++ b/src/Import/LineItems/OneTime.php
@@ -3,9 +3,9 @@
 namespace ChartMogul\Import\LineItems;
 
 /**
-* @codeCoverageIgnore
-* @deprecated Use \ChartMogul\LineItems\OneTime
-*/
+ * @codeCoverageIgnore
+ * @deprecated         Use \ChartMogul\LineItems\OneTime
+ */
 class OneTime extends \ChartMogul\LineItems\OneTime
 {
 }

--- a/src/Import/LineItems/Subscription.php
+++ b/src/Import/LineItems/Subscription.php
@@ -3,9 +3,9 @@
 namespace ChartMogul\Import\LineItems;
 
 /**
-* @codeCoverageIgnore
-* @deprecated Use \ChartMogul\LineItems\Subscription
-*/
+ * @codeCoverageIgnore
+ * @deprecated         Use \ChartMogul\LineItems\Subscription
+ */
 class Subscription extends \ChartMogul\LineItems\Subscription
 {
 }

--- a/src/Import/Transactions/Payment.php
+++ b/src/Import/Transactions/Payment.php
@@ -4,7 +4,7 @@ namespace ChartMogul\Import\Transactions;
 
 /**
  * @codeCoverageIgnore
- * @deprecated Use \ChartMogul\Transactions\Payment
+ * @deprecated         Use \ChartMogul\Transactions\Payment
  */
 class Payment extends \ChartMogul\Transactions\Payment
 {

--- a/src/Import/Transactions/Refund.php
+++ b/src/Import/Transactions/Refund.php
@@ -4,7 +4,7 @@ namespace ChartMogul\Import\Transactions;
 
 /**
  * @codeCoverageIgnore
- * @deprecated Use \ChartMogul\Transactions\Refund
+ * @deprecated         Use \ChartMogul\Transactions\Refund
  */
 class Refund extends \ChartMogul\Transactions\Refund
 {

--- a/src/LineItems/AbstractLineItem.php
+++ b/src/LineItems/AbstractLineItem.php
@@ -3,9 +3,9 @@
 namespace ChartMogul\LineItems;
 
 /**
-* @codeCoverageIgnore
-* @property-read string $uuid
-*/
+ * @codeCoverageIgnore
+ * @property-read      string $uuid
+ */
 abstract class AbstractLineItem extends \ChartMogul\Resource\AbstractModel
 {
     protected $uuid;

--- a/src/LineItems/OneTime.php
+++ b/src/LineItems/OneTime.php
@@ -3,8 +3,8 @@
 namespace ChartMogul\LineItems;
 
 /**
-* @codeCoverageIgnore
-*/
+ * @codeCoverageIgnore
+ */
 class OneTime extends AbstractLineItem
 {
     public $type = 'one_time';

--- a/src/LineItems/Subscription.php
+++ b/src/LineItems/Subscription.php
@@ -3,8 +3,8 @@
 namespace ChartMogul\LineItems;
 
 /**
-* @codeCoverageIgnore
-*/
+ * @codeCoverageIgnore
+ */
 class Subscription extends AbstractLineItem
 {
     public $type = 'subscription';

--- a/src/Metrics.php
+++ b/src/Metrics.php
@@ -12,8 +12,9 @@ class Metrics
 {
     /**
      * Retrieves all key metrics, for the specified time period.
-     * @param array|array $options
-     * @param ClientInterface|null $client
+     *
+     * @param  array|array          $options
+     * @param  ClientInterface|null $client
      * @return NSMetrics\AllKeyMetrics
      */
     public static function all(array $options = [], ClientInterface $client = null)
@@ -22,6 +23,7 @@ class Metrics
     }
     /**
      * Retrieves the Average Revenue Per Account (ARPA), for the specified time period.
+     *
      * @inheritDoc
      */
     public static function arpa(array $options = [], ClientInterface $client = null)
@@ -31,6 +33,7 @@ class Metrics
 
     /**
      * Retrieves the Annualized Run Rate (ARR), for the specified time period.
+     *
      * @inheritDoc
      */
     public static function arr(array $options = [], ClientInterface $client = null)
@@ -40,6 +43,7 @@ class Metrics
 
     /**
      * Retrieves the Average Sale Price (ASP), for the specified time period.
+     *
      * @inheritDoc
      */
     public static function asp(array $options = [], ClientInterface $client = null)
@@ -49,6 +53,7 @@ class Metrics
 
     /**
      * Retrieves the Customer Churn Rate, for the specified time period.
+     *
      * @inheritDoc
      */
     public static function customerChurnRate(array $options = [], ClientInterface $client = null)
@@ -58,6 +63,7 @@ class Metrics
 
     /**
      * Retrieves the number of active customers, for the specified time period.
+     *
      * @inheritDoc
      */
     public static function customerCount(array $options = [], ClientInterface $client = null)
@@ -67,6 +73,7 @@ class Metrics
 
     /**
      * Retrieves the Monthly Recurring Revenue (MRR), for the specified time period.
+     *
      * @inheritDoc
      */
     public static function mrr(array $options = [], ClientInterface $client = null)
@@ -76,6 +83,7 @@ class Metrics
 
     /**
      * Retrieves the Customer Lifetime Value (LTV), for the specified time period.
+     *
      * @inheritDoc
      */
     public static function ltv(array $options = [], ClientInterface $client = null)
@@ -85,6 +93,7 @@ class Metrics
 
     /**
      * Retrieves the Net MRR Churn Rate, for the specified time period.
+     *
      * @inheritDoc
      */
     public static function mrrChurnRate(array $options = [], ClientInterface $client = null)

--- a/src/Metrics/Activity.php
+++ b/src/Metrics/Activity.php
@@ -40,7 +40,8 @@ class Activity extends AbstractModel
 
     /**
      * Returns a list of activities for a given customer.
-     * @param  array $options array with `customer_uuid`
+     *
+     * @param  array                $options array with `customer_uuid`
      * @param  ClientInterface|null $client
      * @return Activities
      */

--- a/src/Metrics/Customers/Activity.php
+++ b/src/Metrics/Customers/Activity.php
@@ -30,7 +30,8 @@ class Activity extends AbstractModel
 
     /**
      * Returns a list of activities for a given customer.
-     * @param  array $options array with `customer_uuid`
+     *
+     * @param  array                $options array with `customer_uuid`
      * @param  ClientInterface|null $client
      * @return Activities
      */

--- a/src/Metrics/Customers/Subscription.php
+++ b/src/Metrics/Customers/Subscription.php
@@ -37,7 +37,8 @@ class Subscription extends AbstractModel
 
     /**
      * Returns a list of subscriptions for a given customer.
-     * @param  array $options array with `customer_uuid`
+     *
+     * @param  array                $options array with `customer_uuid`
      * @param  ClientInterface|null $client
      * @return Subscriptions
      */

--- a/src/Ping.php
+++ b/src/Ping.php
@@ -7,9 +7,9 @@ use ChartMogul\Resource\AbstractResource;
 use ChartMogul\Service\AllTrait;
 
 /**
-* @codeCoverageIgnore
-* @property-read string $uuid
-*/
+ * @codeCoverageIgnore
+ * @property-read      string $uuid
+ */
 class Ping extends AbstractResource
 {
     use AllTrait;

--- a/src/Plan.php
+++ b/src/Plan.php
@@ -10,9 +10,9 @@ use ChartMogul\Service\UpdateTrait;
 use ChartMogul\Service\DestroyTrait;
 
 /**
-* @codeCoverageIgnore
-* @property-read string $uuid
-*/
+ * @codeCoverageIgnore
+ * @property-read      string $uuid
+ */
 class Plan extends AbstractResource
 {
     use AllTrait;

--- a/src/PlanGroup.php
+++ b/src/PlanGroup.php
@@ -10,9 +10,9 @@ use ChartMogul\Service\UpdateTrait;
 use ChartMogul\Service\DestroyTrait;
 
 /**
-* @codeCoverageIgnore
-* @property-read string $uuid
-*/
+ * @codeCoverageIgnore
+ * @property-read      string $uuid
+ */
 class PlanGroup extends AbstractResource
 {
     use AllTrait;

--- a/src/PlanGroups/Plan.php
+++ b/src/PlanGroups/Plan.php
@@ -6,9 +6,9 @@ use ChartMogul\Resource\AbstractResource;
 use ChartMogul\Service\AllTrait;
 
 /**
-* @codeCoverageIgnore
-* @property-read string $uuid
-*/
+ * @codeCoverageIgnore
+ * @property-read      string $uuid
+ */
 class Plan extends AbstractResource
 {
     use AllTrait;

--- a/src/Resource/AbstractModel.php
+++ b/src/Resource/AbstractModel.php
@@ -7,8 +7,8 @@ use Doctrine\Common\Collections\ArrayCollection;
 abstract class AbstractModel
 {
     /**
-    * @codeCoverageIgnore
-    */
+     * @codeCoverageIgnore
+     */
     public function __construct(array $attributes = [])
     {
         foreach ($attributes as $key => $value) {
@@ -39,17 +39,17 @@ abstract class AbstractModel
         return $data;
     }
     /**
-    * @codeCoverageIgnore
-    * @return  array
-    */
+     * @codeCoverageIgnore
+     * @return             array
+     */
     public function toArray()
     {
         return $this->objectToArray($this);
     }
 
     /**
-     * @param array $data
-     * @return self
+     * @param              array $data
+     * @return             self
      * @codeCoverageIgnore
      */
     public static function fromArray(array $data)
@@ -58,9 +58,9 @@ abstract class AbstractModel
     }
 
     /**
-    * @ignore
-    * @codeCoverageIgnore
-    */
+     * @ignore
+     * @codeCoverageIgnore
+     */
     public function __get($name)
     {
         if (isset($this->$name)) {

--- a/src/Resource/AbstractResource.php
+++ b/src/Resource/AbstractResource.php
@@ -8,31 +8,31 @@ use ChartMogul\Http\ClientInterface;
 abstract class AbstractResource extends AbstractModel
 {
     /**
-    * @ignore
-    */
+     * @ignore
+     */
     public const ROOT_KEY = null;
 
     /**
-    * @ignore
-    */
+     * @ignore
+     */
     public const RESOURCE_PATH = null;
 
     /**
-    * @ignore
-    */
+     * @ignore
+     */
     public const RESOURCE_NAME = null;
 
 
     /**
-    * @var ClientInterface
-    */
+     * @var ClientInterface
+     */
     private $client = null;
 
     /**
      * @codeCoverageIgnore
-     * @param array|array $attr
-     * @param ClientInterface|null $client
-     * @return self
+     * @param              array|array          $attr
+     * @param              ClientInterface|null $client
+     * @return             self
      */
     public function __construct(array $attr = [], ClientInterface $client = null)
     {
@@ -45,7 +45,7 @@ abstract class AbstractResource extends AbstractModel
     }
 
     /**
-     * @return ClientInterface
+     * @return             ClientInterface
      * @codeCoverageIgnore
      */
     public function getClient()
@@ -54,8 +54,8 @@ abstract class AbstractResource extends AbstractModel
     }
 
     /**
-     * @param ClientInterface $client
-     * @return self
+     * @param              ClientInterface $client
+     * @return             self
      * @codeCoverageIgnore
      */
     public function setClient(ClientInterface $client)
@@ -65,28 +65,35 @@ abstract class AbstractResource extends AbstractModel
     }
 
     /**
-     * @param array $data
-     * @param ClientInterface|null $client
+     * @param  array                $data
+     * @param  ClientInterface|null $client
      * @return Collection|static
      */
     public static function fromArray(array $data, ClientInterface $client = null)
     {
         if (isset($data[static::ROOT_KEY])) {
             if (static::ROOT_KEY != "subscription_events") {
-                $array = new Collection(array_map(function ($data) use ($client) {
-                    return static::fromArray($data, $client);
-                }, $data[static::ROOT_KEY]));
+                $array = new Collection(
+                    array_map(
+                        function ($data) use ($client) {
+                            return static::fromArray($data, $client);
+                        },
+                        $data[static::ROOT_KEY]
+                    )
+                );
                 // The following are subject to change soon, so they are optional.
                 $array = static::allData($data, $array);
             } else {
-                $array = new SubscriptionEventCollection(array_map(function ($data) use ($client) {
-                    return static::fromArray($data, $client);
-                }, $data[static::ROOT_KEY]));
+                $array = new SubscriptionEventCollection(
+                    array_map(
+                        function ($data) use ($client) {
+                            return static::fromArray($data, $client);
+                        },
+                        $data[static::ROOT_KEY]
+                    )
+                );
 
-                if (isset($data["meta"])) {
-                    $meta = $data['meta'];
-                    $array->meta = static::metaData($meta);
-                }
+                $array = static::allMetaAndCursorData($data, $array);
             }
             return $array;
         }
@@ -110,6 +117,9 @@ abstract class AbstractResource extends AbstractModel
         }
         if (isset($data["page"])) {
             $array->page = $data["page"];
+        }
+        if (isset($data["cursor"])) {
+            $array->cursor = $data["cursor"];
         }
 
         return $array;
@@ -135,5 +145,21 @@ abstract class AbstractResource extends AbstractModel
         }
 
         return $array_meta;
+    }
+
+    public static function allMetaAndCursorData(array $data, SubscriptionEventCollection $array)
+    {
+        if (isset($data["meta"])) {
+            $meta = $data["meta"];
+            $array->meta = static::metaData($meta);
+        }
+        if (isset($data["cursor"])) {
+            $array->cursor = $data["cursor"];
+        }
+        if (isset($data["has_more"])) {
+            $array->has_more = $data["has_more"];
+        }
+
+        return $array;
     }
 }

--- a/src/Resource/Collection.php
+++ b/src/Resource/Collection.php
@@ -7,27 +7,31 @@ use Doctrine\Common\Collections\ArrayCollection;
 class Collection extends ArrayCollection
 {
     /**
-    * @var int
-    */
+     * @var int
+     */
     public $current_page;
     /**
-    * @var int
-    */
+     * @var int
+     */
     public $per_page;
     /**
-    * @var int
-    */
+     * @var int
+     */
     public $page;
     /**
-    * @var int
-    */
+     * @var int
+     */
     public $has_more;
     /**
-    * @var int
-    */
+     * @var string
+     */
+    public $cursor;
+    /**
+     * @var int
+     */
     public $total_pages;
     /**
-    * @var string
-    */
+     * @var string
+     */
     public $customer_uuid;
 }

--- a/src/Resource/CollectionWithCursor.php
+++ b/src/Resource/CollectionWithCursor.php
@@ -7,11 +7,11 @@ use Doctrine\Common\Collections\ArrayCollection;
 class CollectionWithCursor extends ArrayCollection
 {
     /**
-    * @var boolean
-    */
+     * @var boolean
+     */
     public $has_more;
     /**
-    * @var string
-    */
+     * @var string
+     */
     public $cursor;
 }

--- a/src/Resource/MetaCollection.php
+++ b/src/Resource/MetaCollection.php
@@ -7,23 +7,23 @@ use Doctrine\Common\Collections\ArrayCollection;
 class MetaCollection extends ArrayCollection
 {
     /**
-    * @var int
-    */
+     * @var int
+     */
     public $next_key;
     /**
-    * @var int
-    */
+     * @var int
+     */
     public $prev_key;
     /**
-    * @var int
-    */
+     * @var int
+     */
     public $page;
     /**
-    * @var int
-    */
+     * @var int
+     */
     public $total_pages;
     /**
-    * @var string
-    */
+     * @var string
+     */
     public $before_key;
 }

--- a/src/Resource/SubscriptionEventCollection.php
+++ b/src/Resource/SubscriptionEventCollection.php
@@ -7,7 +7,15 @@ use Doctrine\Common\Collections\ArrayCollection;
 class SubscriptionEventCollection extends ArrayCollection
 {
     /**
-    * @array
-    */
+     * @array
+     */
     public $meta;
+    /**
+     * @var int
+     */
+    public $has_more;
+    /**
+     * @var string
+     */
+    public $cursor;
 }

--- a/src/Service/AllTrait.php
+++ b/src/Service/AllTrait.php
@@ -12,10 +12,10 @@ trait AllTrait
 {
     /**
      * Returns a list of objects
-     * @param  array $data
+     *
+     * @param  array                $data
      * @param  ClientInterface|null $client 0
      * @return Collection|self[]|self
-
      */
     public static function all(array $data = [], ClientInterface $client = null)
     {

--- a/src/Service/CreateTrait.php
+++ b/src/Service/CreateTrait.php
@@ -11,6 +11,7 @@ trait CreateTrait
 {
     /**
      * Create a Resource
+     *
      * @param  array                $data
      * @param  ClientInterface|null $client
      * @return self

--- a/src/Service/DestroyTrait.php
+++ b/src/Service/DestroyTrait.php
@@ -11,6 +11,7 @@ trait DestroyTrait
 {
     /**
      * Delete a resource
+     *
      * @return boolean
      */
     public function destroy()

--- a/src/Service/DestroyWithParamsTrait.php
+++ b/src/Service/DestroyWithParamsTrait.php
@@ -11,6 +11,7 @@ trait DestroyWithParamsTrait
 {
     /**
      * Delete a resource
+     *
      * @return boolean
      */
     public static function destroyWithParams(array $params = [], ClientInterface $client = null)

--- a/src/Service/GetTrait.php
+++ b/src/Service/GetTrait.php
@@ -11,6 +11,7 @@ trait GetTrait
 {
     /**
      * Get a single resource by UUID.
+     *
      * @return resource
      */
     public static function retrieve($uuid, ClientInterface $client = null)

--- a/src/Service/RequestService.php
+++ b/src/Service/RequestService.php
@@ -41,7 +41,8 @@ class RequestService
 
     /**
      * Use only when default class resource path must be overridden.
-     * @param string $resourcePath
+     *
+     * @param  string $resourcePath
      * @return $this
      */
     public function setResourcePath($resourcePath)
@@ -52,11 +53,17 @@ class RequestService
 
     private function getNamedParams($path)
     {
-        return array_map(function ($item) {
-            return substr($item, 1);
-        }, array_filter(explode('/', $path), function ($part) {
-            return strpos($part, ':') === 0;
-        }));
+        return array_map(
+            function ($item) {
+                return substr($item, 1);
+            },
+            array_filter(
+                explode('/', $path),
+                function ($part) {
+                    return strpos($part, ':') === 0;
+                }
+            )
+        );
     }
 
     private function applyResourcePath(&$data)
@@ -154,7 +161,7 @@ class RequestService
 
         $class = $this->resourceClass;
         $response = $client->setResourceKey($class::RESOURCE_NAME)
-                            ->send($this->applyResourcePath($id), 'PATCH', $params);
+            ->send($this->applyResourcePath($id), 'PATCH', $params);
 
         return $class::fromArray($response, $this->client);
     }
@@ -178,7 +185,7 @@ class RequestService
 
         $class = $this->resourceClass;
         $response = $client->setResourceKey($class::RESOURCE_NAME)
-                            ->send($this->applyResourcePath($id), 'DELETE', $params);
+            ->send($this->applyResourcePath($id), 'DELETE', $params);
 
         return true;
     }

--- a/src/Service/ShowTrait.php
+++ b/src/Service/ShowTrait.php
@@ -11,6 +11,7 @@ trait ShowTrait
 {
     /**
      * Show details of current resource.
+     *
      * @return resource
      */
 

--- a/src/Service/UpdateTrait.php
+++ b/src/Service/UpdateTrait.php
@@ -11,6 +11,7 @@ trait UpdateTrait
 {
     /**
      * Update a Resource
+     *
      * @param  array                $data
      * @param  ClientInterface|null $client
      * @return self

--- a/src/Service/UpdateWithParamsTrait.php
+++ b/src/Service/UpdateWithParamsTrait.php
@@ -11,6 +11,7 @@ trait UpdateWithParamsTrait
 {
     /**
      * Update a Resource
+     *
      * @param  array                $params
      * @param  ClientInterface|null $client
      * @return self

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -62,26 +62,32 @@ class Subscription extends AbstractResource
 
     /**
      * Cancels a subscription that was generated from an imported invoice.
+     *
      * @param  string $cancelledAt The time at which the subscription was cancelled.
      * @return Subscription
      */
     public function cancel($cancelledAt)
     {
-        return $this->cancellation([
+        return $this->cancellation(
+            [
             'cancelled_at' => $cancelledAt
-        ]);
+            ]
+        );
     }
 
     /**
      * Changes dates of cancellation for a subscription.
+     *
      * @param  array $cancellationDates The array of times (strings) at which the subscription was cancelled.
      * @return Subscription
      */
     public function setCancellationDates($cancellationDates)
     {
-        return $this->cancellation([
+        return $this->cancellation(
+            [
             'cancellation_dates' => $cancellationDates
-        ]);
+            ]
+        );
     }
 
     /**
@@ -98,14 +104,15 @@ class Subscription extends AbstractResource
 
     /**
      * Connect Subscriptions
-     * @param  string               $customerUUID Customer UUID
-     * @param  Subscription[]       $subscriptions Array of Subscription to connect this subscription with
+     *
+     * @param  string         $customerUUID  Customer UUID
+     * @param  Subscription[] $subscriptions Array of Subscription to connect this subscription with
      * @return bool
      */
     public function connect($customerUUID, array $subscriptions)
     {
         $arr = [];
-        for ($i=0; $i < count($subscriptions); $i++) {
+        for ($i = 0; $i < count($subscriptions); $i++) {
             $arr[$i] = $subscriptions[$i];
             if ($subscriptions[$i] instanceof Subscription) {
                 $arr[$i] = $subscriptions[$i]->toArray();
@@ -115,9 +122,13 @@ class Subscription extends AbstractResource
         array_unshift($arr, $this->toArray());
 
         $this->getClient()
-            ->send('/v1/customers/'.$customerUUID.'/connect_subscriptions', 'POST', [
+            ->send(
+                '/v1/customers/'.$customerUUID.'/connect_subscriptions',
+                'POST',
+                [
                 'subscriptions' => $arr,
-            ]);
+                ]
+            );
         return true;
     }
 }

--- a/src/Transactions/Payment.php
+++ b/src/Transactions/Payment.php
@@ -3,11 +3,11 @@
 namespace ChartMogul\Transactions;
 
 /**
-* @codeCoverageIgnore
-*/
+ * @codeCoverageIgnore
+ */
 class Payment extends AbstractTransaction
 {
-    public const RESOURCE_NAME= 'Payment Transaction';
+    public const RESOURCE_NAME = 'Payment Transaction';
 
 
     public $type = 'payment';

--- a/src/Transactions/Refund.php
+++ b/src/Transactions/Refund.php
@@ -3,11 +3,11 @@
 namespace ChartMogul\Transactions;
 
 /**
-* @codeCoverageIgnore
-*/
+ * @codeCoverageIgnore
+ */
 class Refund extends AbstractTransaction
 {
-    public const RESOURCE_NAME= 'Refund Transaction';
+    public const RESOURCE_NAME = 'Refund Transaction';
 
     public $type = 'refund';
 }

--- a/tests/Unit/AccountTest.php
+++ b/tests/Unit/AccountTest.php
@@ -10,30 +10,30 @@ use ChartMogul\Exceptions\NotFoundException;
 
 class AccountTest extends TestCase
 {
-  const RETRIEVE_ACCOUNT = '{
+    const RETRIEVE_ACCOUNT = '{
     "name": "Example Test Company",
     "currency": "EUR",
     "time_zone": "Europe/Berlin",
     "week_start_on": "sunday"
   }';
 
-  public function testRetrieveAccount()
-  {
-      $stream = Psr7\stream_for(AccountTest::RETRIEVE_ACCOUNT);
-      list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+    public function testRetrieveAccount()
+    {
+        $stream = Psr7\stream_for(AccountTest::RETRIEVE_ACCOUNT);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
 
-      $result = Account::retrieve($cmClient);
-      $request = $mockClient->getRequests()[0];
+        $result = Account::retrieve($cmClient);
+        $request = $mockClient->getRequests()[0];
 
-      $this->assertEquals("GET", $request->getMethod());
-      $uri = $request->getUri();
-      $this->assertEquals("", $uri->getQuery());
-      $this->assertEquals("/v1/account", $uri->getPath());
+        $this->assertEquals("GET", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("", $uri->getQuery());
+        $this->assertEquals("/v1/account", $uri->getPath());
 
-      $this->assertTrue($result instanceof Account);
-      $this->assertEquals($result->name, "Example Test Company");
-      $this->assertEquals($result->currency, "EUR");
-      $this->assertEquals($result->time_zone, "Europe/Berlin");
-      $this->assertEquals($result->week_start_on, "sunday");
-  }
+        $this->assertTrue($result instanceof Account);
+        $this->assertEquals($result->name, "Example Test Company");
+        $this->assertEquals($result->currency, "EUR");
+        $this->assertEquals($result->time_zone, "Europe/Berlin");
+        $this->assertEquals($result->week_start_on, "sunday");
+    }
 }

--- a/tests/Unit/ContactTest.php
+++ b/tests/Unit/ContactTest.php
@@ -100,7 +100,8 @@ class ContactTest extends TestCase
         $stream = Psr7\stream_for(ContactTest::CONTACT_JSON);
         list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
 
-        $result = Contact::create([
+        $result = Contact::create(
+            [
             "customer_uuid" => "cus_00000000-0000-0000-0000-000000000000",
             "data_source_uuid" => "ds_00000000-0000-0000-0000-000000000000",
             "first_name" => "Adam",
@@ -116,7 +117,8 @@ class ContactTest extends TestCase
               [ "key" => "Facebook", "value" => "https://www.facebook.com/adam.smith" ],
               [ "key" => "date_of_birth", "value" => "1985-01-22" ]
             ],
-        ], $cmClient);
+            ], $cmClient
+        );
         $request = $mockClient->getRequests()[0];
 
         $this->assertEquals("POST", $request->getMethod());
@@ -153,7 +155,8 @@ class ContactTest extends TestCase
 
         $uuid = "con_00000000-0000-0000-0000-000000000000";
 
-        $result = Contact::update([
+        $result = Contact::update(
+            [
             "contact_uuid" => $uuid,
             ], [
             "first_name" => "Bill",
@@ -169,7 +172,8 @@ class ContactTest extends TestCase
               [ "key" => "Facebook", "value" => "https://www.facebook.com/bill.thompson" ],
               [ "key" => "date_of_birth", "value" => "1990-01-01" ]
             ],
-        ], $cmClient);
+            ], $cmClient
+        );
         $request = $mockClient->getRequests()[0];
 
         $this->assertEquals("PATCH", $request->getMethod());

--- a/tests/Unit/Exceptions/ChartMogulExceptionTest.php
+++ b/tests/Unit/Exceptions/ChartMogulExceptionTest.php
@@ -8,22 +8,24 @@ use Nyholm\Psr7\Response;
 class ChartMogulExceptionTest extends \PHPUnit\Framework\TestCase
 {
 
-	public function testConstruct()
-	{
-		$psr17Factory = new Psr17Factory();
+    public function testConstruct()
+    {
+        $psr17Factory = new Psr17Factory();
 
-		// Test non-JSON response
-		$mock = new Response(200, [], 'plain text');
-		$e = new ChartMogulException('message', $mock);
-		$this->assertEquals($e->getStatusCode(), 200);
-		$this->assertEquals($e->getResponse(), 'plain text');
+        // Test non-JSON response
+        $mock = new Response(200, [], 'plain text');
+        $e = new ChartMogulException('message', $mock);
+        $this->assertEquals($e->getStatusCode(), 200);
+        $this->assertEquals($e->getResponse(), 'plain text');
 
-		// Test JSON response
-		$mock = new Response(200, [], '{"result": "json"}');
-		$e = new ChartMogulException('message', $mock);
-		$this->assertEquals($e->getStatusCode(), 200);
-		$this->assertEquals($e->getResponse(), [
-			"result" => "json"
-		]);
-	}
+        // Test JSON response
+        $mock = new Response(200, [], '{"result": "json"}');
+        $e = new ChartMogulException('message', $mock);
+        $this->assertEquals($e->getStatusCode(), 200);
+        $this->assertEquals(
+            $e->getResponse(), [
+            "result" => "json"
+            ]
+        );
+    }
 }

--- a/tests/Unit/Http/ClientTest.php
+++ b/tests/Unit/Http/ClientTest.php
@@ -10,23 +10,23 @@ use Http\Client\HttpClient;
 
 class ClientTest extends TestCase
 {
-	public function setUp(): void
-	{
-		parent::setUp();
-		$psr17Factory = new Psr17Factory();
-		$this->emptyStream = $psr17Factory->createStream('{}');
-	}
+    public function setUp(): void
+    {
+        parent::setUp();
+        $psr17Factory = new Psr17Factory();
+        $this->emptyStream = $psr17Factory->createStream('{}');
+    }
 
-	public function testConstructor()
-	{
-		$configStub = $this->getMockBuilder(\ChartMogul\Configuration::class)
-		                   ->disableOriginalConstructor()
-		                   ->getMock();
+    public function testConstructor()
+    {
+        $configStub = $this->getMockBuilder(\ChartMogul\Configuration::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
-		$client = new Client($configStub);
-		$this->assertEquals($configStub, $client->getConfiguration());
-		$this->assertInstanceOf(HttpClient::class, $client->getHttpClient());
-	}
+        $client = new Client($configStub);
+        $this->assertEquals($configStub, $client->getConfiguration());
+        $this->assertInstanceOf(HttpClient::class, $client->getHttpClient());
+    }
 
     public function testGetUserAgent()
     {
@@ -35,7 +35,7 @@ class ClientTest extends TestCase
             ->onlyMethods([])
             ->getMock();
 
-        $this->assertEquals("chartmogul-php/5.1.2/PHP-".PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION, $mock->getUserAgent());
+        $this->assertEquals("chartmogul-php/5.1.3/PHP-".PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION, $mock->getUserAgent());
     }
 
     public function testGetBasicAuthHeader()
@@ -54,17 +54,17 @@ class ClientTest extends TestCase
     }
 
 
-	public function testHandleResponseOK()
-	{
-		$mock = $this->getMockBuilder(Client::class)
-		             ->disableOriginalConstructor()
-		             ->onlyMethods([])
-		             ->getMock();
+    public function testHandleResponseOK()
+    {
+        $mock = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
 
-		$res = new Response(200, [], '{"result": "json"}');
-		$data = $mock->handleResponse($res);
-		$this->assertEquals($data, ['result' => 'json']);
-	}
+        $res = new Response(200, [], '{"result": "json"}');
+        $data = $mock->handleResponse($res);
+        $this->assertEquals($data, ['result' => 'json']);
+    }
 
     public static function provider()
     {
@@ -81,17 +81,17 @@ class ClientTest extends TestCase
     /**
      * @dataProvider provider
      */
-	public function testHandleResponseExceptions($status, $exception)
-	{
-		$this->expectException($exception);
-		$mock = $this->getMockBuilder(Client::class)
-		             ->disableOriginalConstructor()
-		             ->onlyMethods([])
-		             ->getMock();
+    public function testHandleResponseExceptions($status, $exception)
+    {
+        $this->expectException($exception);
+        $mock = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
 
-		$res = new Response($status, [], 'plain text');
-		$mock->handleResponse($res);
-	}
+        $res = new Response($status, [], 'plain text');
+        $mock->handleResponse($res);
+    }
 
     public static function providerSend()
     {
@@ -146,9 +146,11 @@ class ClientTest extends TestCase
     }
     public function testRetryNetworkError()
     {
-        list($mock, $mockClient) = $this->getMockClient(10, [200], $this->emptyStream, [
+        list($mock, $mockClient) = $this->getMockClient(
+            10, [200], $this->emptyStream, [
             new \Http\Client\Exception\NetworkException("some error", $this->createMock('Psr\Http\Message\RequestInterface')),
-        ]);
+            ]
+        );
 
         $mock->send('', 'GET', []);
         $this->assertEquals(count($mockClient->getRequests()), 2);
@@ -157,10 +159,12 @@ class ClientTest extends TestCase
     public function testRetryMaxAttemptReached()
     {
         $this->expectException(NetworkException::class);
-        list($mock, $mockClient) = $this->getMockClient(1, [200], $this->emptyStream, [
+        list($mock, $mockClient) = $this->getMockClient(
+            1, [200], $this->emptyStream, [
             new \Http\Client\Exception\NetworkException("some error", $this->createMock('Psr\Http\Message\RequestInterface')),
             new \Http\Client\Exception\NetworkException("some error", $this->createMock('Psr\Http\Message\RequestInterface')),
-        ]);
+            ]
+        );
 
 
         $returnedResponse = $mock->send('', 'GET', []);

--- a/tests/Unit/InvoiceTest.php
+++ b/tests/Unit/InvoiceTest.php
@@ -11,7 +11,7 @@ use ChartMogul\Exceptions\NotFoundException;
 
 class InvoiceTest extends TestCase
 {
-    const ALL_INVOICE_JSON = '{
+    const ALL_INVOICES_JSON = '{
       "invoices": [
         {
           "uuid": "inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9",
@@ -120,21 +120,81 @@ class InvoiceTest extends TestCase
       ]
     }';
 
+    const ALL_INVOICES_NEW_PAGINATION_JSON = '{
+      "invoices": [
+        {
+          "uuid": "inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9",
+          "customer_uuid": "cus_f466e33d-ff2b-4a11-8f85-417eb02157a7",
+          "external_id": "INV0001",
+          "date": "2015-11-01T00:00:00.000Z",
+          "due_date": "2015-11-15T00:00:00.000Z",
+          "currency": "USD",
+          "line_items": [
+            {
+              "uuid": "li_d72e6843-5793-41d0-bfdf-0269514c9c56",
+              "external_id": null,
+              "type": "subscription",
+              "subscription_uuid": "sub_e6bc5407-e258-4de0-bb43-61faaf062035",
+              "plan_uuid": "pl_eed05d54-75b4-431b-adb2-eb6b9e543206",
+              "prorated": false,
+              "service_period_start": "2015-11-01T00:00:00.000Z",
+              "service_period_end": "2015-12-01T00:00:00.000Z",
+              "amount_in_cents": 5000,
+              "quantity": 1,
+              "discount_code": "PSO86",
+              "discount_amount_in_cents": 1000,
+              "tax_amount_in_cents": 900,
+              "transaction_fees_currency": "EUR",
+              "discount_description": "5 EUR",
+              "account_code": null
+            },
+            {
+              "uuid": "li_0cc8c112-beac-416d-af11-f35744ca4e83",
+              "external_id": null,
+              "type": "one_time",
+              "description": "Setup Fees",
+              "amount_in_cents": 2500,
+              "quantity": 1,
+              "discount_code": "PSO86",
+              "discount_amount_in_cents": 500,
+              "tax_amount_in_cents": 450,
+              "transaction_fees_currency": "EUR",
+              "discount_description": "2 EUR",
+              "account_code": null
+            }
+          ],
+          "transactions": [
+            {
+              "uuid": "tr_879d560a-1bec-41bb-986e-665e38a2f7bc",
+              "external_id": null,
+              "type": "payment",
+              "date": "2015-11-05T00:14:23.000Z",
+              "result": "successful"
+            }
+          ]
+        }
+      ],
+      "has_more": false,
+      "cursor": "cursor=="
+    }';
+
     public function testCreateInvoiceFailsOnValidation()
     {
-      $stream = Psr7\stream_for('{invoices: [{errors: {"plan_id": "doesn\'t exist"}}]}');
-      list($cmClient, $mockClient) = $this->getMockClient(0, [422], $stream);
+        $stream = Psr7\stream_for('{invoices: [{errors: {"plan_id": "doesn\'t exist"}}]}');
+        list($cmClient, $mockClient) = $this->getMockClient(0, [422], $stream);
 
-      $this->expectException(\ChartMogul\Exceptions\SchemaInvalidException::class);
-      $restult = CustomerInvoices::create([
-      'customer_uuid' => 'some_id',
-      'invoices' => [['mock' => 'invoice']]
-      ], $cmClient);
+        $this->expectException(\ChartMogul\Exceptions\SchemaInvalidException::class);
+        $restult = CustomerInvoices::create(
+            [
+            'customer_uuid' => 'some_id',
+            'invoices' => [['mock' => 'invoice']]
+            ], $cmClient
+        );
     }
 
     public function testAllInvoices()
     {
-        $stream = Psr7\stream_for(InvoiceTest::ALL_INVOICE_JSON);
+        $stream = Psr7\stream_for(InvoiceTest::ALL_INVOICES_JSON);
         list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
 
         $query = ["page" => 2, "external_id" => "INV0001"];
@@ -151,6 +211,27 @@ class InvoiceTest extends TestCase
         $this->assertEquals("cus_f466e33d-ff2b-4a11-8f85-417eb02157a7", $result[0]->customer_uuid);
         $this->assertEquals(2, $result->current_page);
         $this->assertEquals(3, $result->total_pages);
+    }
+
+    public function testAllInvoicesNewPagination()
+    {
+        $stream = Psr7\stream_for(InvoiceTest::ALL_INVOICES_NEW_PAGINATION_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $query = ["page" => 2, "external_id" => "INV0001"];
+        $result = Invoice::all($query, $cmClient);
+        $request = $mockClient->getRequests()[0];
+
+        $this->assertEquals("GET", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("page=2&external_id=INV0001", $uri->getQuery());
+        $this->assertEquals("/v1/invoices", $uri->getPath());
+
+        $this->assertEquals(1, sizeof($result));
+        $this->assertTrue($result[0] instanceof Invoice);
+        $this->assertEquals("cus_f466e33d-ff2b-4a11-8f85-417eb02157a7", $result[0]->customer_uuid);
+        $this->assertFalse($result->has_more);
+        $this->assertEquals($result->cursor, "cursor==");
     }
 
     public function testDestroyInvoice()

--- a/tests/Unit/Metrics/Customers/CustomerActivityTest.php
+++ b/tests/Unit/Metrics/Customers/CustomerActivityTest.php
@@ -26,9 +26,28 @@ class CustomerActivityTest extends TestCase
               "subscription-external-id": "1"
             }
         ],
-        "has_more":false,
-        "per_page":200,
-        "page":1
+        "has_more": false,
+        "per_page": 200,
+        "page": 1
+    }';
+
+    const ALL_NEW_PAGINATION_JSON = '{
+        "entries":[
+            {
+              "activity-arr": 24000,
+              "activity-mrr": 2000,
+              "activity-mrr-movement": 2000,
+              "currency": "USD",
+              "currency-sign": "$",
+              "date": "2015-06-09T13:16:00-04:00",
+              "description": "purchased the Silver Monthly plan (1)",
+              "id": 48730,
+              "type": "new_biz",
+              "subscription-external-id": "1"
+            }
+        ],
+        "has_more": false,
+        "cursor": "cursor=="
     }';
 
 
@@ -37,7 +56,7 @@ class CustomerActivityTest extends TestCase
         $stream = Psr7\stream_for(CustomerActivityTest::ALL_JSON);
         list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
 
-        $result = Activity::all(['customer_uuid'=>'cus_0fe70ccc-8e23-11eb-a532-031f31dc363e'],$cmClient);
+        $result = Activity::all(['customer_uuid'=>'cus_0fe70ccc-8e23-11eb-a532-031f31dc363e'], $cmClient);
         $request = $mockClient->getRequests()[0];
 
         $this->assertEquals("GET", $request->getMethod());
@@ -46,6 +65,21 @@ class CustomerActivityTest extends TestCase
 
         $this->assertTrue($result->entries[0] instanceof Activity);
         $this->assertEquals($result->entries[0]->type, "new_biz");
+    }
 
+    public function testAllNewPagination()
+    {
+        $stream = Psr7\stream_for(CustomerActivityTest::ALL_NEW_PAGINATION_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $result = Activity::all(['customer_uuid'=>'cus_0fe70ccc-8e23-11eb-a532-031f31dc363e'], $cmClient);
+        $request = $mockClient->getRequests()[0];
+
+        $this->assertEquals("GET", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/customers/cus_0fe70ccc-8e23-11eb-a532-031f31dc363e/activities", $uri->getPath());
+
+        $this->assertEquals($result->cursor, "cursor==");
+        $this->assertFalse($result->has_more);
     }
 }

--- a/tests/Unit/Metrics/Customers/CustomerSubscriptionTest.php
+++ b/tests/Unit/Metrics/Customers/CustomerSubscriptionTest.php
@@ -34,13 +34,35 @@ class CustomerSubscriptionTest extends TestCase
         "page":1
     }';
 
+    const ALL_NEW_PAGINATION_JSON = '{
+        "entries":[
+            {
+                "id": 9306830,
+                "external_id": "sub_0001",
+                "plan": "PRO Plan (10,000 active cust.) monthly",
+                "quantity": 1,
+                "mrr": 70800,
+                "arr": 849600,
+                "status": "active",
+                "billing-cycle": "month",
+                "billing-cycle-count": 1,
+                "start-date": "2015-12-20T08:26:49-05:00",
+                "end-date": "2016-03-20T09:26:49-05:00",
+                "currency": "USD",
+                "currency-sign": "$"
+            }
+        ],
+        "has_more":false,
+        "cursor": "cursor=="
+    }';
+
 
     public function testAll()
     {
         $stream = Psr7\stream_for(CustomerSubscriptionTest::ALL_JSON);
         list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
 
-        $result = Subscription::all(['customer_uuid'=>'cus_0fe70ccc-8e23-11eb-a532-031f31dc363e'],$cmClient);
+        $result = Subscription::all(['customer_uuid'=>'cus_0fe70ccc-8e23-11eb-a532-031f31dc363e'], $cmClient);
         $request = $mockClient->getRequests()[0];
 
         $this->assertEquals("GET", $request->getMethod());
@@ -49,6 +71,21 @@ class CustomerSubscriptionTest extends TestCase
 
         $this->assertTrue($result->entries[0] instanceof Subscription);
         $this->assertEquals($result->entries[0]->external_id, "sub_0001");
+    }
 
+    public function testAllNewPagination()
+    {
+        $stream = Psr7\stream_for(CustomerSubscriptionTest::ALL_NEW_PAGINATION_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $result = Subscription::all(['customer_uuid'=>'cus_0fe70ccc-8e23-11eb-a532-031f31dc363e'], $cmClient);
+        $request = $mockClient->getRequests()[0];
+
+        $this->assertEquals("GET", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/customers/cus_0fe70ccc-8e23-11eb-a532-031f31dc363e/subscriptions", $uri->getPath());
+
+        $this->assertEquals($result->cursor, "cursor==");
+        $this->assertFalse($result->has_more);
     }
 }

--- a/tests/Unit/Metrics/MetricsTest.php
+++ b/tests/Unit/Metrics/MetricsTest.php
@@ -67,7 +67,7 @@ class MetricsTest extends TestCase
         $stream = Psr7\stream_for(MetricsTest::ALL_JSON);
         list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
 
-        $result = Metrics::all(["interval" => "month"],$cmClient);
+        $result = Metrics::all(["interval" => "month"], $cmClient);
         $request = $mockClient->getRequests()[0];
 
         $this->assertEquals("GET", $request->getMethod());
@@ -79,15 +79,18 @@ class MetricsTest extends TestCase
         $this->assertEquals($result->entries[0]->date, "2015-01-31");
 
     }
-    public function testLtv(){
+    public function testLtv()
+    {
 
         $stream = Psr7\stream_for(MetricsTest::LTV_JSON);
         list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
 
-        $result = Metrics::ltv([
+        $result = Metrics::ltv(
+            [
             "start-date" => "2015-01-01",
             "end-date" => "2015-11-01",
-        ],$cmClient);
+            ], $cmClient
+        );
         $request = $mockClient->getRequests()[0];
 
         $this->assertEquals("GET", $request->getMethod());

--- a/tests/Unit/PlanGroups/PlanTest.php
+++ b/tests/Unit/PlanGroups/PlanTest.php
@@ -9,53 +9,95 @@ use GuzzleHttp\Psr7\Response;
 class PlanGroupsPlanTest extends TestCase
 {
     const ALL_PLAN_GROUPS_PLANS_JSON = '{
-    "plans": [
-      {
-        "name": "A Test Plan",
-        "uuid": "pl_2f7f4360-3633-0138-f01f-62b37fb4c770",
-        "data_source_uuid":"ds_424b9628-5405-11ea-ab18-e3a0f4f45097",
-        "interval_count":1,
-        "interval_unit":"month",
-        "external_id":"2f7f4360-3633-0138-f01f-62b37fb4c770"
-      },
-      {
-        "name":"Another Test Plan",
-        "uuid": "pl_3011ead0-3633-0138-f020-62b37fb4c770",
-        "data_source_uuid": "ds_424b9628-5405-11ea-ab18-e3a0f4f45097",
-        "interval_count": 1,
-        "interval_unit": "month",
-        "external_id": "3011ead0-3633-0138-f020-62b37fb4c770"
-      }
-    ],
-    "current_page": 1,
-    "total_pages": 1
-  }';
+      "plans": [
+        {
+          "name": "A Test Plan",
+          "uuid": "pl_2f7f4360-3633-0138-f01f-62b37fb4c770",
+          "data_source_uuid":"ds_424b9628-5405-11ea-ab18-e3a0f4f45097",
+          "interval_count":1,
+          "interval_unit":"month",
+          "external_id":"2f7f4360-3633-0138-f01f-62b37fb4c770"
+        },
+        {
+          "name":"Another Test Plan",
+          "uuid": "pl_3011ead0-3633-0138-f020-62b37fb4c770",
+          "data_source_uuid": "ds_424b9628-5405-11ea-ab18-e3a0f4f45097",
+          "interval_count": 1,
+          "interval_unit": "month",
+          "external_id": "3011ead0-3633-0138-f020-62b37fb4c770"
+        }
+      ],
+      "current_page": 1,
+      "total_pages": 1
+    }';
+
+    const ALL_PLAN_GROUPS_PLANS_NEW_PAGINATION_JSON = '{
+      "plans": [
+        {
+          "name": "A Test Plan",
+          "uuid": "pl_2f7f4360-3633-0138-f01f-62b37fb4c770",
+          "data_source_uuid":"ds_424b9628-5405-11ea-ab18-e3a0f4f45097",
+          "interval_count":1,
+          "interval_unit":"month",
+          "external_id":"2f7f4360-3633-0138-f01f-62b37fb4c770"
+        },
+        {
+          "name":"Another Test Plan",
+          "uuid": "pl_3011ead0-3633-0138-f020-62b37fb4c770",
+          "data_source_uuid": "ds_424b9628-5405-11ea-ab18-e3a0f4f45097",
+          "interval_count": 1,
+          "interval_unit": "month",
+          "external_id": "3011ead0-3633-0138-f020-62b37fb4c770"
+        }
+      ],
+      "has_more": false,
+      "cursor": "cursor=="
+    }';
 
     public function testAllPlanGroups()
     {
-      $stream = Psr7\stream_for(PlanGroupsPlanTest::ALL_PLAN_GROUPS_PLANS_JSON);
-      list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+        $stream = Psr7\stream_for(PlanGroupsPlanTest::ALL_PLAN_GROUPS_PLANS_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
 
-      $planGroupUuid = 'plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab';
-      $query = [
+        $planGroupUuid = 'plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab';
+        $query = [
         "plan_group_uuid" => $planGroupUuid,
         "page" => 1,
         "per_page" => 2
-      ];
+        ];
 
-      $result = Plan::all($query, $cmClient);
-      $request = $mockClient->getRequests()[0];
+        $result = Plan::all($query, $cmClient);
+        $request = $mockClient->getRequests()[0];
 
-      $this->assertEquals("GET", $request->getMethod());
-      $uri = $request->getUri();
-      $this->assertEquals("/v1/plan_groups/$planGroupUuid/plans", $uri->getPath());
-      $this->assertEquals("page=1&per_page=2", $uri->getQuery());
+        $this->assertEquals("GET", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/plan_groups/$planGroupUuid/plans", $uri->getPath());
+        $this->assertEquals("page=1&per_page=2", $uri->getQuery());
 
-      $this->assertEquals(2, sizeof($result));
-      $this->assertTrue($result[0] instanceof Plan);
-      $this->assertEquals("pl_2f7f4360-3633-0138-f01f-62b37fb4c770", $result[0]->uuid);
-      $this->assertEquals("ds_424b9628-5405-11ea-ab18-e3a0f4f45097", $result[0]->data_source_uuid);
-      $this->assertEquals(1, $result->current_page);
-      $this->assertEquals(1, $result->total_pages);
+        $this->assertEquals(2, sizeof($result));
+        $this->assertTrue($result[0] instanceof Plan);
+        $this->assertEquals("pl_2f7f4360-3633-0138-f01f-62b37fb4c770", $result[0]->uuid);
+        $this->assertEquals("ds_424b9628-5405-11ea-ab18-e3a0f4f45097", $result[0]->data_source_uuid);
+        $this->assertEquals(1, $result->current_page);
+        $this->assertEquals(1, $result->total_pages);
+    }
+
+    public function testAllPlanGroupsNewPagination()
+    {
+        $stream = Psr7\stream_for(PlanGroupsPlanTest::ALL_PLAN_GROUPS_PLANS_NEW_PAGINATION_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $planGroupUuid = 'plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab';
+        $query = [
+        "plan_group_uuid" => $planGroupUuid,
+        "page" => 1,
+        "per_page" => 2
+        ];
+
+        $result = Plan::all($query, $cmClient);
+        $request = $mockClient->getRequests()[0];
+
+        $this->assertEquals($result->cursor, "cursor==");
+        $this->assertFalse($result->has_more);
     }
 }

--- a/tests/Unit/Resources/AbstractModelTest.php
+++ b/tests/Unit/Resources/AbstractModelTest.php
@@ -4,9 +4,6 @@ use ChartMogul\Resource\AbstractModel;
 
 class AbstractModelTest extends \PHPUnit\Framework\TestCase
 {
-
-
-
     public static function provider()
     {
         return [

--- a/tests/Unit/SubscriptionEventTest.php
+++ b/tests/Unit/SubscriptionEventTest.php
@@ -10,217 +10,280 @@ use ChartMogul\Exceptions\ChartMogulException;
 class SubscriptionEventTest extends TestCase
 {
     const ALL_SUBSCRIPTION_EVENT_JSON = '{
-    "subscription_events": [
+      "subscription_events": [
+        {
+          "id": 73966836,
+        	"data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+        	"customer_external_id": "scus_023",
+        	"subscription_set_external_id": "sub_set_ex_id_1",
+        	"subscription_external_id": "sub_0023",
+        	"plan_external_id": "p_ex_id_1",
+        	"event_date": "2022-04-09T11:17:14Z",
+        	"effective_date": "2022-04-09T10:04:13Z",
+        	"event_type": "subscription_cancelled",
+        	"external_id": "ex_id_1",
+        	"errors": {},
+        	"created_at": "2022-04-09T11:17:14Z",
+        	"updated_at": "2022-04-09T11:17:14Z",
+        	"quantity": 1,
+        	"currency": "USD",
+        	"amount_in_cents": 1000
+        },
+        {
+          "id": 73966837,
+        	"data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+        	"customer_external_id": "scus_024",
+        	"subscription_set_external_id": "sub_set_ex_id_2",
+        	"subscription_external_id": "sub_0024",
+        	"plan_external_id": "p_ex_id_2",
+        	"event_date": "2022-04-09T11:17:14Z",
+        	"effective_date": "2022-04-09T10:04:13Z",
+        	"event_type": "subscription_cancelled",
+        	"external_id": "ex_id_2",
+        	"errors": {},
+        	"created_at": "2022-04-09T11:17:14Z",
+        	"updated_at": "2022-04-09T11:17:14Z",
+        	"quantity": 1,
+        	"currency": "USD",
+        	"amount_in_cents": 1000
+        }
+      ],
+      "meta":
       {
-        "id": 73966836,
-      	"data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
-      	"customer_external_id": "scus_023",
-      	"subscription_set_external_id": "sub_set_ex_id_1",
-      	"subscription_external_id": "sub_0023",
-      	"plan_external_id": "p_ex_id_1",
-      	"event_date": "2022-04-09T11:17:14Z",
-      	"effective_date": "2022-04-09T10:04:13Z",
-      	"event_type": "subscription_cancelled",
-      	"external_id": "ex_id_1",
-      	"errors": {},
-      	"created_at": "2022-04-09T11:17:14Z",
-      	"updated_at": "2022-04-09T11:17:14Z",
-      	"quantity": 1,
-      	"currency": "USD",
-      	"amount_in_cents": 1000
-      },
-      {
-        "id": 73966837,
-      	"data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
-      	"customer_external_id": "scus_024",
-      	"subscription_set_external_id": "sub_set_ex_id_2",
-      	"subscription_external_id": "sub_0024",
-      	"plan_external_id": "p_ex_id_2",
-      	"event_date": "2022-04-09T11:17:14Z",
-      	"effective_date": "2022-04-09T10:04:13Z",
-      	"event_type": "subscription_cancelled",
-      	"external_id": "ex_id_2",
-      	"errors": {},
-      	"created_at": "2022-04-09T11:17:14Z",
-      	"updated_at": "2022-04-09T11:17:14Z",
-      	"quantity": 1,
-      	"currency": "USD",
-      	"amount_in_cents": 1000
+          "next_key": 67048503,
+          "prev_key": null,
+          "before_key": "2022-04-10T22:27:35.834Z",
+          "page": 1,
+          "total_pages": 166
       }
-    ],
-    "meta":
+    }';
+
+    const ALL_SUBSCRIPTION_EVENT_NEW_PAGINATION_JSON = '{
+      "subscription_events": [
+        {
+          "id": 73966836,
+          "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+          "customer_external_id": "scus_023",
+          "subscription_set_external_id": "sub_set_ex_id_1",
+          "subscription_external_id": "sub_0023",
+          "plan_external_id": "p_ex_id_1",
+          "event_date": "2022-04-09T11:17:14Z",
+          "effective_date": "2022-04-09T10:04:13Z",
+          "event_type": "subscription_cancelled",
+          "external_id": "ex_id_1",
+          "errors": {},
+          "created_at": "2022-04-09T11:17:14Z",
+          "updated_at": "2022-04-09T11:17:14Z",
+          "quantity": 1,
+          "currency": "USD",
+          "amount_in_cents": 1000
+        },
+        {
+          "id": 73966837,
+          "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+          "customer_external_id": "scus_024",
+          "subscription_set_external_id": "sub_set_ex_id_2",
+          "subscription_external_id": "sub_0024",
+          "plan_external_id": "p_ex_id_2",
+          "event_date": "2022-04-09T11:17:14Z",
+          "effective_date": "2022-04-09T10:04:13Z",
+          "event_type": "subscription_cancelled",
+          "external_id": "ex_id_2",
+          "errors": {},
+          "created_at": "2022-04-09T11:17:14Z",
+          "updated_at": "2022-04-09T11:17:14Z",
+          "quantity": 1,
+          "currency": "USD",
+          "amount_in_cents": 1000
+        }
+      ],
+      "has_more": false,
+      "cursor": "cursor=="
+    }';
+
+    const RETRIEVE_SUBSCRIPTION_EVENT = '{
+      "id": 73966836,
+      "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+      "customer_external_id": "scus_023",
+      "subscription_set_external_id": "sub_set_ex_id_1",
+      "subscription_external_id": "sub_0023",
+      "plan_external_id": "p_ex_id_1",
+      "event_date": "2022-04-09T11:17:14Z",
+      "effective_date": "2022-04-09T10:04:13Z",
+      "event_type": "subscription_cancelled",
+      "external_id": "ex_id_1",
+      "created_at": "2022-04-09T11:17:14Z",
+      "updated_at": "2022-04-09T11:17:14Z",
+      "quantity": 1,
+      "currency": "USD",
+      "amount_in_cents": 1000
+    }';
+
+    const UPDATE_SUBSCRIPTION_EVENT = '{
+      "id": 73966836,
+      "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+      "customer_external_id": "scus_023",
+      "subscription_set_external_id": "sub_set_ex_id_1",
+      "subscription_external_id": "sub_0023",
+      "plan_external_id": "p_ex_id_1",
+      "event_date": "2022-04-09T11:17:14Z",
+      "effective_date": "2022-04-09T10:04:13Z",
+      "event_type": "subscription_cancelled",
+      "external_id": "ex_id_1",
+      "created_at": "2022-04-09T11:17:14Z",
+      "updated_at": "2022-04-09T11:17:14Z",
+      "quantity": 1,
+      "currency": "EUR",
+      "amount_in_cents": 100
+    }';
+
+    public function testAllSubscriptionEvents()
     {
-        "next_key": 67048503,
-        "prev_key": null,
-        "before_key": "2022-04-10T22:27:35.834Z",
-        "page": 1,
-        "total_pages": 166
+        $stream = Psr7\stream_for(SubscriptionEventTest::ALL_SUBSCRIPTION_EVENT_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $result = SubscriptionEvent::all([], $cmClient);
+        $request = $mockClient->getRequests()[0];
+
+        $this->assertEquals("GET", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/subscription_events", $uri->getPath());
+
+        $this->assertEquals(2, sizeof($result));
+        $this->assertTrue($result[0] instanceof SubscriptionEvent);
+        $this->assertEquals("ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba", $result[0]->data_source_uuid);
+        $this->assertEquals("scus_023", $result[0]->customer_external_id);
+        $this->assertEquals(166, $result->meta->total_pages);
+        $this->assertEquals(1, $result->meta->page);
+        $this->assertEquals("2022-04-10T22:27:35.834Z", $result->meta->before_key);
     }
-  }';
-  const RETRIEVE_SUBSCRIPTION_EVENT = '{
-    "id": 73966836,
-    "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
-    "customer_external_id": "scus_023",
-    "subscription_set_external_id": "sub_set_ex_id_1",
-    "subscription_external_id": "sub_0023",
-    "plan_external_id": "p_ex_id_1",
-    "event_date": "2022-04-09T11:17:14Z",
-    "effective_date": "2022-04-09T10:04:13Z",
-    "event_type": "subscription_cancelled",
-    "external_id": "ex_id_1",
-    "created_at": "2022-04-09T11:17:14Z",
-    "updated_at": "2022-04-09T11:17:14Z",
-    "quantity": 1,
-    "currency": "USD",
-    "amount_in_cents": 1000
-  }';
 
-  const UPDATE_SUBSCRIPTION_EVENT = '{
-    "id": 73966836,
-    "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
-    "customer_external_id": "scus_023",
-    "subscription_set_external_id": "sub_set_ex_id_1",
-    "subscription_external_id": "sub_0023",
-    "plan_external_id": "p_ex_id_1",
-    "event_date": "2022-04-09T11:17:14Z",
-    "effective_date": "2022-04-09T10:04:13Z",
-    "event_type": "subscription_cancelled",
-    "external_id": "ex_id_1",
-    "created_at": "2022-04-09T11:17:14Z",
-    "updated_at": "2022-04-09T11:17:14Z",
-    "quantity": 1,
-    "currency": "EUR",
-    "amount_in_cents": 100
-  }';
+    public function testAllSubscriptionEventsNewPagination()
+    {
+        $stream = Psr7\stream_for(
+            SubscriptionEventTest::ALL_SUBSCRIPTION_EVENT_NEW_PAGINATION_JSON
+        );
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
 
-   public function testAllSubscriptionEvents()
-   {
-     $stream = Psr7\stream_for(SubscriptionEventTest::ALL_SUBSCRIPTION_EVENT_JSON);
-     list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+        $result = SubscriptionEvent::all([], $cmClient);
+        $request = $mockClient->getRequests()[0];
 
-     $result = SubscriptionEvent::all([],$cmClient);
-     $request = $mockClient->getRequests()[0];
+        $this->assertEquals("cursor==", $result->cursor);
+        $this->assertFalse($result->has_more);
+    }
 
-     $this->assertEquals("GET", $request->getMethod());
-     $uri = $request->getUri();
-     $this->assertEquals("/v1/subscription_events", $uri->getPath());
+    public function testCreateSubscriptionEvent()
+    {
+        $stream = Psr7\stream_for(SubscriptionEventTest::RETRIEVE_SUBSCRIPTION_EVENT);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
 
-     $this->assertEquals(2, sizeof($result));
-     $this->assertTrue($result[0] instanceof SubscriptionEvent);
-     $this->assertEquals("ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba", $result[0]->data_source_uuid);
-     $this->assertEquals("scus_023", $result[0]->customer_external_id);
-     $this->assertEquals(166, $result->meta->total_pages);
-     $this->assertEquals(1, $result->meta->page);
-     $this->assertEquals("2022-04-10T22:27:35.834Z", $result->meta->before_key);
-   }
+        $customer_external_id = 'scus_023';
+        $data_source_uuid = "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba";
+        $event_type = 'subscription_start_scheduled';
+        $event_date = '2022-03-30';
+        $effective_date = '2022-04-01';
 
-   public function testCreateSubscriptionEvent()
-   {
-     $stream = Psr7\stream_for(SubscriptionEventTest::RETRIEVE_SUBSCRIPTION_EVENT);
-     list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+        $result = SubscriptionEvent::create(
+            [
+            "customer_external_id" => $customer_external_id,
+            "data_source_uuid" => $data_source_uuid,
+            "event_type" => $event_type,
+            "event_date" => $event_date,
+            "effective_date" => $effective_date,
+            ],
+            $cmClient
+        );
 
-     $customer_external_id = 'scus_023';
-     $data_source_uuid = "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba";
-     $event_type = 'subscription_start_scheduled';
-     $event_date = '2022-03-30';
-     $effective_date = '2022-04-01';
+        $request = $mockClient->getRequests()[0];
 
-     $result = SubscriptionEvent::create([
-        "customer_external_id" => $customer_external_id,
-        "data_source_uuid" => $data_source_uuid,
-        "event_type" => $event_type,
-        "event_date" => $event_date,
-        "effective_date" => $effective_date,
-     ],
-     $cmClient
-     );
+        $this->assertEquals("POST", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("", $uri->getQuery());
+        $this->assertEquals("/v1/subscription_events", $uri->getPath());
 
-     $request = $mockClient->getRequests()[0];
+        $this->assertTrue($result instanceof SubscriptionEvent);
+        $this->assertEquals("scus_023", $result->customer_external_id);
+    }
 
-     $this->assertEquals("POST", $request->getMethod());
-     $uri = $request->getUri();
-     $this->assertEquals("", $uri->getQuery());
-     $this->assertEquals("/v1/subscription_events", $uri->getPath());
+    public function testUpdateSubscriptionEventWithId()
+    {
+        $stream = Psr7\stream_for(SubscriptionEventTest::UPDATE_SUBSCRIPTION_EVENT);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
 
-     $this->assertTrue($result instanceof SubscriptionEvent);
-     $this->assertEquals("scus_023", $result->customer_external_id);
-   }
+        $id = 73966836;
+        $new_amount = 100;
 
-   public function testUpdateSubscriptionEventWithId()
-   {
-     $stream = Psr7\stream_for(SubscriptionEventTest::UPDATE_SUBSCRIPTION_EVENT);
-     list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+        $result = SubscriptionEvent::updateWithParams(
+            ['subscription_event' => [
+            "id" => $id, 'amount_in_cents' => $new_amount
+            ]],
+            $cmClient
+        );
 
-     $id = 73966836;
-     $new_amount = 100;
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals("PATCH", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("", $uri->getQuery());
+        $this->assertEquals("/v1/subscription_events", $uri->getPath());
+        $this->assertTrue($result instanceof SubscriptionEvent);
+        $this->assertEquals($result->amount_in_cents, $new_amount);
+    }
 
-     $result = SubscriptionEvent::updateWithParams(['subscription_event' => [
-        "id" => $id, 'amount_in_cents' => $new_amount
-       ]],
-       $cmClient
-     );
+    public function testUpdateSubscriptionEventWithDataSourceUuidAndExternalId()
+    {
+        $stream = Psr7\stream_for(SubscriptionEventTest::UPDATE_SUBSCRIPTION_EVENT);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
 
-     $request = $mockClient->getRequests()[0];
-     $this->assertEquals("PATCH", $request->getMethod());
-     $uri = $request->getUri();
-     $this->assertEquals("", $uri->getQuery());
-     $this->assertEquals("/v1/subscription_events", $uri->getPath());
-     $this->assertTrue($result instanceof SubscriptionEvent);
-     $this->assertEquals($result->amount_in_cents, $new_amount);
-   }
+        $data_source_uuid = "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba";
+        $external_id = "ex_id_1";
+        $new_amount = 100;
 
-   public function testUpdateSubscriptionEventWithDataSourceUuidAndExternalId()
-   {
-     $stream = Psr7\stream_for(SubscriptionEventTest::UPDATE_SUBSCRIPTION_EVENT);
-     list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+        $result = SubscriptionEvent::updateWithParams(
+            ['subscription_event' => [
+            "data_source_uuid" => $data_source_uuid, "external_id" => $external_id, 'amount_in_cents' => $new_amount
+            ]], $cmClient
+        );
 
-     $data_source_uuid = "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba";
-     $external_id = "ex_id_1";
-     $new_amount = 100;
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals("PATCH", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("", $uri->getQuery());
+        $this->assertEquals("/v1/subscription_events", $uri->getPath());
+        $this->assertTrue($result instanceof SubscriptionEvent);
+        $this->assertEquals($result->amount_in_cents, $new_amount);
+    }
 
-     $result = SubscriptionEvent::updateWithParams(['subscription_event' => [
-       "data_source_uuid" => $data_source_uuid, "external_id" => $external_id, 'amount_in_cents' => $new_amount
-       ]],$cmClient
-     );
+    public function testDestroySubscriptionEventWithId()
+    {
+        list($cmClient, $mockClient) = $this->getMockClient(0, [204]);
+        $id = 73966836;
 
-     $request = $mockClient->getRequests()[0];
-     $this->assertEquals("PATCH", $request->getMethod());
-     $uri = $request->getUri();
-     $this->assertEquals("", $uri->getQuery());
-     $this->assertEquals("/v1/subscription_events", $uri->getPath());
-     $this->assertTrue($result instanceof SubscriptionEvent);
-     $this->assertEquals($result->amount_in_cents, $new_amount);
-   }
+        $result = SubscriptionEvent::destroyWithParams(['subscription_event' => ["id" => $id]], $cmClient);
 
-   public function testDestroySubscriptionEventWithId()
-   {
-     list($cmClient, $mockClient) = $this->getMockClient(0, [204]);
-     $id = 73966836;
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals("DELETE", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("", $uri->getQuery());
+        $this->assertEquals("/v1/subscription_events", $uri->getPath());
+        $this->assertEquals($result, true);
+    }
 
-     $result = SubscriptionEvent::destroyWithParams(['subscription_event' => ["id" => $id]], $cmClient);
+    public function testDestroySubscriptionEventWithDataSourceUuidAndExternalId()
+    {
+        list($cmClient, $mockClient) = $this->getMockClient(0, [204]);
+        $data_source_uuid = "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba";
+        $external_id = "ex_id_1";
 
-     $request = $mockClient->getRequests()[0];
-     $this->assertEquals("DELETE", $request->getMethod());
-     $uri = $request->getUri();
-     $this->assertEquals("", $uri->getQuery());
-     $this->assertEquals("/v1/subscription_events", $uri->getPath());
-     $this->assertEquals($result, true);
-   }
-
-   public function testDestroySubscriptionEventWithDataSourceUuidAndExternalId()
-   {
-      list($cmClient, $mockClient) = $this->getMockClient(0, [204]);
-      $data_source_uuid = "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba";
-      $external_id = "ex_id_1";
-
-      $result = SubscriptionEvent::destroyWithParams(['subscription_event' => [
-        "data_source_uuid" => $data_source_uuid, "external_id" => $external_id]
-      ],$cmClient);
-      $request = $mockClient->getRequests()[0];
-      $this->assertEquals("DELETE", $request->getMethod());
-      $uri = $request->getUri();
-      $this->assertEquals("", $uri->getQuery());
-      $this->assertEquals("/v1/subscription_events", $uri->getPath());
-      $this->assertEquals($result, true);
-   }
+        $result = SubscriptionEvent::destroyWithParams(
+            ['subscription_event' => [
+            "data_source_uuid" => $data_source_uuid, "external_id" => $external_id]
+            ], $cmClient
+        );
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals("DELETE", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("", $uri->getQuery());
+        $this->assertEquals("/v1/subscription_events", $uri->getPath());
+        $this->assertEquals($result, true);
+    }
 }

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -14,7 +14,8 @@ class TestCase extends \PHPUnit\Framework\TestCase
         HttpClientDiscovery::prependStrategy(MockClientStrategy::class);
     }
 
-    protected function getMockClient($retries, $statuses, $stream = null, $exceptions = []){
+    protected function getMockClient($retries, $statuses, $stream = null, $exceptions = [])
+    {
         $mock = $this->getMockBuilder(Client::class)
             ->onlyMethods(['getBasicAuthHeader', 'getUserAgent'])
             ->getMock();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,8 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-if (!class_exists('\PHPUnit\Framework\TestCase') &&
-    class_exists('\PHPUnit_Framework_TestCase')) {
+if (!class_exists('\PHPUnit\Framework\TestCase')
+    && class_exists('\PHPUnit_Framework_TestCase')
+) {
     class_alias('\PHPUnit_Framework_TestCase', 'PHPUnit\Framework\TestCase');
 }


### PR DESCRIPTION
## Changelog

- Support cursor based pagination
- Lint the project using phpcs and phpcbf to adhere to the PHP standards

We currently have another [PR open](https://github.com/chartmogul/chartmogul-php/pull/110) that adds cursor pagination to the library but removes the old pagination as a breaking change. This adds the support for the new pagination in case there is a server regression and we end up with broken clients out there.