### PR TITLE
remove support for `page` query params

### DIFF
--- a/6.0-Upgrade.md
+++ b/6.0-Upgrade.md
@@ -1,0 +1,32 @@
+# Upgrading to chartmogul-php 6.0.0
+
+This new version replaces the existing pagination for the `.all()` endpoints that used a combination of `page` and `per_page` parameters, and instead uses a `cursor` based pagination. So to list (as an example) Plans you now can:
+
+```php
+// Getting the first page
+$plans = ChartMogul\Plan::all([
+    "per_page" => 1
+]);
+
+// This will return an array of plans (if available), and a cursor + has_more fields
+{
+    "plans": [
+        {
+            "uuid": "some_uuid",
+            "data_source_uuid": "some_uuid",
+            "name": "Master Plan"
+        }
+    ],
+    "has_more": true,
+    "cursor": "MjAyMy0wNy0yOFQwODowOToyMi4xNTQyMDMwMDBaJjk0NDQ0Mg=="
+}
+
+if ($plans->has_more) {
+    $more_plans = ChartMogul\Plan::all([
+        "per_page" => 1,
+        "cursor" => $plans->cursor
+    ])
+}
+```
+
+If you have existing code that relies on the `page` parameter, those requests will throw an error now alerting you of their deprecation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [6.0.0] - 2023-10-30
+
+### Removed
+- Support for old pagination using `page` query params.
+
 ## [5.1.3] - 2023-10-03
 
 ### Added

--- a/src/Exceptions/DeprecatedParameterException.php
+++ b/src/Exceptions/DeprecatedParameterException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ChartMogul\Exceptions;
+
+/**
+ * DeprecatedParameterException Interface
+ *
+ * @codeCoverageIgnore
+ */
+class DeprecatedParameterException extends ChartMogulException
+{
+}

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -30,7 +30,7 @@ class Client implements ClientInterface
     /**
      * @var string
      */
-    private $apiVersion = '5.1.3';
+    private $apiVersion = '6.0.0';
 
     /**
      * @var string
@@ -163,6 +163,12 @@ class Client implements ClientInterface
 
     public function send($path = '', $method = 'GET', $data = [])
     {
+        if (isset($data['page'])) {
+            throw new \ChartMogul\Exceptions\DeprecatedParameterException(
+                "The 'page' query parameter is deprecated"
+            );
+        }
+
         $query = '';
         if ($method === 'GET') {
             $query = http_build_query($data);

--- a/tests/Unit/CustomerTest.php
+++ b/tests/Unit/CustomerTest.php
@@ -153,36 +153,6 @@ class CustomerTest extends TestCase
         }
       ],
       "has_more":false,
-      "per_page":200,
-      "page":1
-    }';
-
-    const SEARCH_CUSTOMER_NEW_PAGINATION_JSON = '{
-      "entries":[
-        {
-          "id": 25647,
-          "uuid": "cus_de305d54-75b4-431b-adb2-eb6b9e546012",
-          "external_id": "34916129",
-          "email": "bob@examplecompany.com",
-          "name": "Example Company",
-          "address": {
-            "address_zip": "0185128",
-            "city": "Nowhereville",
-            "country": "US",
-            "state": "Alaska"
-          },
-          "mrr": 3000,
-          "arr": 36000,
-          "status": "Active",
-          "customer-since": "2015-06-09T13:16:00-04:00",
-          "billing-system-url": "https:\/\/dashboard.stripe.com\/customers\/cus_4Z2ZpyJFuQ0XMb",
-          "chartmogul-url": "https:\/\/app.chartmogul.com\/#customers\/25647-Example_Company",
-          "billing-system-type": "Stripe",
-          "currency": "USD",
-          "currency-sign": "$"
-        }
-      ],
-      "has_more":false,
       "cursor": "cursor=="
     }';
 
@@ -250,6 +220,7 @@ class CustomerTest extends TestCase
         $this->assertTrue($result instanceof Customer);
         $this->assertEquals($uuid, $result->uuid);
     }
+
     public function testCreateCustomer()
     {
         $stream = Psr7\stream_for(CustomerTest::CREATE_CUSTOMER_JSON);
@@ -276,34 +247,11 @@ class CustomerTest extends TestCase
 
         $this->assertTrue($result instanceof Customer);
     }
+
     public function testSearchCustomer()
     {
-
         $stream = Psr7\stream_for(CustomerTest::SEARCH_CUSTOMER_JSON);
         list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
-
-
-        $email = "bob@examplecompany.com";
-        $result = Customer::search($email, $cmClient);
-        $request = $mockClient->getRequests()[0];
-
-        $this->assertEquals("GET", $request->getMethod());
-        $uri = $request->getUri();
-        $this->assertEquals("email=".urlencode($email), $uri->getQuery());
-        $this->assertEquals("/v1/customers/search", $uri->getPath());
-
-        $this->assertTrue($result instanceof Collection);
-        $this->assertTrue($result[0] instanceof Customer);
-        $this->assertEquals($result->has_more, false);
-        $this->assertEquals($result->page, 1);
-        $this->assertEquals($result->per_page, 200);
-    }
-    public function testSearchCustomerNewPagination()
-    {
-
-        $stream = Psr7\stream_for(CustomerTest::SEARCH_CUSTOMER_NEW_PAGINATION_JSON);
-        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
-
 
         $email = "bob@examplecompany.com";
         $result = Customer::search($email, $cmClient);
@@ -319,6 +267,7 @@ class CustomerTest extends TestCase
         $this->assertEquals($result->has_more, false);
         $this->assertEquals($result->cursor, "cursor==");
     }
+
     public function testConnectSubscriptions()
     {
         $stream = Psr7\stream_for('{}');
@@ -350,10 +299,8 @@ class CustomerTest extends TestCase
 
     public function testFindByExternalId()
     {
-
         $stream = Psr7\stream_for(CustomerTest::SEARCH_CUSTOMER_JSON);
         list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
-
 
         $result = Customer::findByExternalId("34916129", $cmClient);
         $request = $mockClient->getRequests()[0];
@@ -362,7 +309,6 @@ class CustomerTest extends TestCase
         $uri = $request->getUri();
         $this->assertEquals("external_id=34916129", $uri->getQuery());
         $this->assertEquals("/v1/customers", $uri->getPath());
-
         $this->assertTrue($result instanceof Customer);
     }
 

--- a/tests/Unit/Http/ClientTest.php
+++ b/tests/Unit/Http/ClientTest.php
@@ -35,7 +35,7 @@ class ClientTest extends TestCase
             ->onlyMethods([])
             ->getMock();
 
-        $this->assertEquals("chartmogul-php/5.1.3/PHP-".PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION, $mock->getUserAgent());
+        $this->assertEquals("chartmogul-php/6.0.0/PHP-".PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION, $mock->getUserAgent());
     }
 
     public function testGetBasicAuthHeader()

--- a/tests/Unit/InvoiceTest.php
+++ b/tests/Unit/InvoiceTest.php
@@ -65,8 +65,8 @@ class InvoiceTest extends TestCase
           ]
         }
       ],
-      "current_page": 2,
-      "total_pages": 3
+      "has_more": false,
+      "cursor": "cursor=="
     }';
 
     const RETRIEVE_INVOICE_JSON = '{
@@ -120,71 +120,13 @@ class InvoiceTest extends TestCase
       ]
     }';
 
-    const ALL_INVOICES_NEW_PAGINATION_JSON = '{
-      "invoices": [
-        {
-          "uuid": "inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9",
-          "customer_uuid": "cus_f466e33d-ff2b-4a11-8f85-417eb02157a7",
-          "external_id": "INV0001",
-          "date": "2015-11-01T00:00:00.000Z",
-          "due_date": "2015-11-15T00:00:00.000Z",
-          "currency": "USD",
-          "line_items": [
-            {
-              "uuid": "li_d72e6843-5793-41d0-bfdf-0269514c9c56",
-              "external_id": null,
-              "type": "subscription",
-              "subscription_uuid": "sub_e6bc5407-e258-4de0-bb43-61faaf062035",
-              "plan_uuid": "pl_eed05d54-75b4-431b-adb2-eb6b9e543206",
-              "prorated": false,
-              "service_period_start": "2015-11-01T00:00:00.000Z",
-              "service_period_end": "2015-12-01T00:00:00.000Z",
-              "amount_in_cents": 5000,
-              "quantity": 1,
-              "discount_code": "PSO86",
-              "discount_amount_in_cents": 1000,
-              "tax_amount_in_cents": 900,
-              "transaction_fees_currency": "EUR",
-              "discount_description": "5 EUR",
-              "account_code": null
-            },
-            {
-              "uuid": "li_0cc8c112-beac-416d-af11-f35744ca4e83",
-              "external_id": null,
-              "type": "one_time",
-              "description": "Setup Fees",
-              "amount_in_cents": 2500,
-              "quantity": 1,
-              "discount_code": "PSO86",
-              "discount_amount_in_cents": 500,
-              "tax_amount_in_cents": 450,
-              "transaction_fees_currency": "EUR",
-              "discount_description": "2 EUR",
-              "account_code": null
-            }
-          ],
-          "transactions": [
-            {
-              "uuid": "tr_879d560a-1bec-41bb-986e-665e38a2f7bc",
-              "external_id": null,
-              "type": "payment",
-              "date": "2015-11-05T00:14:23.000Z",
-              "result": "successful"
-            }
-          ]
-        }
-      ],
-      "has_more": false,
-      "cursor": "cursor=="
-    }';
-
     public function testCreateInvoiceFailsOnValidation()
     {
         $stream = Psr7\stream_for('{invoices: [{errors: {"plan_id": "doesn\'t exist"}}]}');
         list($cmClient, $mockClient) = $this->getMockClient(0, [422], $stream);
 
         $this->expectException(\ChartMogul\Exceptions\SchemaInvalidException::class);
-        $restult = CustomerInvoices::create(
+        $result = CustomerInvoices::create(
             [
             'customer_uuid' => 'some_id',
             'invoices' => [['mock' => 'invoice']]
@@ -192,39 +134,30 @@ class InvoiceTest extends TestCase
         );
     }
 
+    public function testAllInvoicesDeprecatedPagination()
+    {
+        $stream = Psr7\stream_for(InvoiceTest::ALL_INVOICES_JSON);
+        list($cmClient, $mockClient) = $this->getMockClientException(
+          0, [200], $stream, [\ChartMogul\Exceptions\DeprecatedParameterException::class]
+        );
+
+        // $this->expectException(\ChartMogul\Exceptions\DeprecatedParameterException::class);
+        $query = ["page" => 2, "external_id" => "INV0001"];
+        $result = Invoice::all($query, $cmClient);
+    }
+
     public function testAllInvoices()
     {
         $stream = Psr7\stream_for(InvoiceTest::ALL_INVOICES_JSON);
         list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
 
-        $query = ["page" => 2, "external_id" => "INV0001"];
+        $query = ["per_page" => 2, "external_id" => "INV0001"];
         $result = Invoice::all($query, $cmClient);
         $request = $mockClient->getRequests()[0];
 
         $this->assertEquals("GET", $request->getMethod());
         $uri = $request->getUri();
-        $this->assertEquals("page=2&external_id=INV0001", $uri->getQuery());
-        $this->assertEquals("/v1/invoices", $uri->getPath());
-
-        $this->assertEquals(1, sizeof($result));
-        $this->assertTrue($result[0] instanceof Invoice);
-        $this->assertEquals("cus_f466e33d-ff2b-4a11-8f85-417eb02157a7", $result[0]->customer_uuid);
-        $this->assertEquals(2, $result->current_page);
-        $this->assertEquals(3, $result->total_pages);
-    }
-
-    public function testAllInvoicesNewPagination()
-    {
-        $stream = Psr7\stream_for(InvoiceTest::ALL_INVOICES_NEW_PAGINATION_JSON);
-        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
-
-        $query = ["page" => 2, "external_id" => "INV0001"];
-        $result = Invoice::all($query, $cmClient);
-        $request = $mockClient->getRequests()[0];
-
-        $this->assertEquals("GET", $request->getMethod());
-        $uri = $request->getUri();
-        $this->assertEquals("page=2&external_id=INV0001", $uri->getQuery());
+        $this->assertEquals("per_page=2&external_id=INV0001", $uri->getQuery());
         $this->assertEquals("/v1/invoices", $uri->getPath());
 
         $this->assertEquals(1, sizeof($result));

--- a/tests/Unit/Metrics/Customers/CustomerSubscriptionTest.php
+++ b/tests/Unit/Metrics/Customers/CustomerSubscriptionTest.php
@@ -10,31 +10,7 @@ use GuzzleHttp\Psr7\Response;
 
 class CustomerSubscriptionTest extends TestCase
 {
-
     const ALL_JSON = '{
-        "entries":[
-            {
-                "id": 9306830,
-                "external_id": "sub_0001",
-                "plan": "PRO Plan (10,000 active cust.) monthly",
-                "quantity": 1,
-                "mrr": 70800,
-                "arr": 849600,
-                "status": "active",
-                "billing-cycle": "month",
-                "billing-cycle-count": 1,
-                "start-date": "2015-12-20T08:26:49-05:00",
-                "end-date": "2016-03-20T09:26:49-05:00",
-                "currency": "USD",
-                "currency-sign": "$"
-            }
-        ],
-        "has_more":false,
-        "per_page":200,
-        "page":1
-    }';
-
-    const ALL_NEW_PAGINATION_JSON = '{
         "entries":[
             {
                 "id": 9306830,
@@ -56,7 +32,6 @@ class CustomerSubscriptionTest extends TestCase
         "cursor": "cursor=="
     }';
 
-
     public function testAll()
     {
         $stream = Psr7\stream_for(CustomerSubscriptionTest::ALL_JSON);
@@ -67,25 +42,30 @@ class CustomerSubscriptionTest extends TestCase
 
         $this->assertEquals("GET", $request->getMethod());
         $uri = $request->getUri();
-        $this->assertEquals("/v1/customers/cus_0fe70ccc-8e23-11eb-a532-031f31dc363e/subscriptions", $uri->getPath());
+        $this->assertEquals(
+            "/v1/customers/cus_0fe70ccc-8e23-11eb-a532-031f31dc363e/subscriptions",
+            $uri->getPath()
+        );
 
         $this->assertTrue($result->entries[0] instanceof Subscription);
         $this->assertEquals($result->entries[0]->external_id, "sub_0001");
-    }
-
-    public function testAllNewPagination()
-    {
-        $stream = Psr7\stream_for(CustomerSubscriptionTest::ALL_NEW_PAGINATION_JSON);
-        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
-
-        $result = Subscription::all(['customer_uuid'=>'cus_0fe70ccc-8e23-11eb-a532-031f31dc363e'], $cmClient);
-        $request = $mockClient->getRequests()[0];
-
-        $this->assertEquals("GET", $request->getMethod());
-        $uri = $request->getUri();
-        $this->assertEquals("/v1/customers/cus_0fe70ccc-8e23-11eb-a532-031f31dc363e/subscriptions", $uri->getPath());
-
         $this->assertEquals($result->cursor, "cursor==");
         $this->assertFalse($result->has_more);
+    }
+
+    public function testAllDeprecatedPagination()
+    {
+        $stream = Psr7\stream_for(CustomerSubscriptionTest::ALL_JSON);
+        list($cmClient, $mockClient) = $this->getMockClientException(
+          0, [200], $stream, [\ChartMogul\Exceptions\DeprecatedParameterException::class]
+        );
+
+        $result = Subscription::all(
+            [
+                "customer_uuid" => "cus_0fe70ccc-8e23-11eb-a532-031f31dc363e",
+                "page" => 1
+            ],
+            $cmClient
+        );
     }
 }

--- a/tests/Unit/PlanGroups/PlanTest.php
+++ b/tests/Unit/PlanGroups/PlanTest.php
@@ -27,29 +27,6 @@ class PlanGroupsPlanTest extends TestCase
           "external_id": "3011ead0-3633-0138-f020-62b37fb4c770"
         }
       ],
-      "current_page": 1,
-      "total_pages": 1
-    }';
-
-    const ALL_PLAN_GROUPS_PLANS_NEW_PAGINATION_JSON = '{
-      "plans": [
-        {
-          "name": "A Test Plan",
-          "uuid": "pl_2f7f4360-3633-0138-f01f-62b37fb4c770",
-          "data_source_uuid":"ds_424b9628-5405-11ea-ab18-e3a0f4f45097",
-          "interval_count":1,
-          "interval_unit":"month",
-          "external_id":"2f7f4360-3633-0138-f01f-62b37fb4c770"
-        },
-        {
-          "name":"Another Test Plan",
-          "uuid": "pl_3011ead0-3633-0138-f020-62b37fb4c770",
-          "data_source_uuid": "ds_424b9628-5405-11ea-ab18-e3a0f4f45097",
-          "interval_count": 1,
-          "interval_unit": "month",
-          "external_id": "3011ead0-3633-0138-f020-62b37fb4c770"
-        }
-      ],
       "has_more": false,
       "cursor": "cursor=="
     }';
@@ -61,9 +38,8 @@ class PlanGroupsPlanTest extends TestCase
 
         $planGroupUuid = 'plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab';
         $query = [
-        "plan_group_uuid" => $planGroupUuid,
-        "page" => 1,
-        "per_page" => 2
+            "plan_group_uuid" => $planGroupUuid,
+            "per_page" => 2
         ];
 
         $result = Plan::all($query, $cmClient);
@@ -72,32 +48,28 @@ class PlanGroupsPlanTest extends TestCase
         $this->assertEquals("GET", $request->getMethod());
         $uri = $request->getUri();
         $this->assertEquals("/v1/plan_groups/$planGroupUuid/plans", $uri->getPath());
-        $this->assertEquals("page=1&per_page=2", $uri->getQuery());
+        $this->assertEquals("per_page=2", $uri->getQuery());
 
         $this->assertEquals(2, sizeof($result));
         $this->assertTrue($result[0] instanceof Plan);
         $this->assertEquals("pl_2f7f4360-3633-0138-f01f-62b37fb4c770", $result[0]->uuid);
         $this->assertEquals("ds_424b9628-5405-11ea-ab18-e3a0f4f45097", $result[0]->data_source_uuid);
-        $this->assertEquals(1, $result->current_page);
-        $this->assertEquals(1, $result->total_pages);
-    }
-
-    public function testAllPlanGroupsNewPagination()
-    {
-        $stream = Psr7\stream_for(PlanGroupsPlanTest::ALL_PLAN_GROUPS_PLANS_NEW_PAGINATION_JSON);
-        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
-
-        $planGroupUuid = 'plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab';
-        $query = [
-        "plan_group_uuid" => $planGroupUuid,
-        "page" => 1,
-        "per_page" => 2
-        ];
-
-        $result = Plan::all($query, $cmClient);
-        $request = $mockClient->getRequests()[0];
-
         $this->assertEquals($result->cursor, "cursor==");
         $this->assertFalse($result->has_more);
+    }
+
+    public function testAllPlanGroupsDeprecatedPagination()
+    {
+        $stream = Psr7\stream_for(PlanGroupsPlanTest::ALL_PLAN_GROUPS_PLANS_JSON);
+        list($cmClient, $mockClient) = $this->getMockClientException(
+          0, [200], $stream, [\ChartMogul\Exceptions\DeprecatedParameterException::class]
+        );
+
+        $query = [
+            "plan_group_uuid" => 'plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab',
+            "page" => 1,
+            "per_page" => 2
+        ];
+        $result = Plan::all($query, $cmClient);
     }
 }

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -41,4 +41,19 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $mock->setHttpClient($mockClient);
         return [$mock, $mockClient];
     }
+
+    protected function getMockClientException($retries, $statuses, $stream = null, $exceptions = [])
+    {
+        foreach($exceptions as $exception) {
+            $this->expectException($exception);
+        }
+
+        $mock = $this->getMockBuilder(Client::class)
+            ->onlyMethods(['getBasicAuthHeader', 'getUserAgent'])
+            ->getMock();
+        $mock->setConfiguration(\ChartMogul\Configuration::getDefaultConfiguration()->setRetries($retries));
+        $mockClient = $mock->getHttpClient();
+        $mock->setHttpClient($mockClient);
+        return [$mock, $mockClient];
+    }
 }


### PR DESCRIPTION
After we released `v5.1.3` to [add support for the cursor based pagination](https://github.com/chartmogul/chartmogul-php/releases/tag/v5.1.3), this new version **removes that support** and will throw an error if the `page` pagination parameter is used.