### PR TITLE
Fix/Deprecation

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Client\ClientInterface as HttpClient;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\RequestFactoryInterface;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
 
 class Client implements ClientInterface
@@ -54,7 +54,7 @@ class Client implements ClientInterface
         RequestFactoryInterface $requestFactory = null
     ) {
         $this->config = $config ?: Configuration::getDefaultConfiguration();
-        $this->client = $client ?: HttpClientDiscovery::find();
+        $this->client = $client ?: Psr18ClientDiscovery::find();
         $this->requestFactory = $requestFactory ?: Psr17FactoryDiscovery::findRequestFactory();
     }
 


### PR DESCRIPTION
Hi @pkopac @sbrych,

HttpClientDiscovery is deprecated
https://github.com/php-http/discovery/blob/1.x/src/HttpClientDiscovery.php#L13

We should use `Psr18ClientDiscovery` instead.
Since `Http\Client\HttpClient` extends `Psr\Http\Client\ClientInterface` this change shouldn't be a BC break.