### PR TITLE
PHP8.3: Add Resources fields

### DIFF
--- a/src/Customer.php
+++ b/src/Customer.php
@@ -82,6 +82,9 @@ class Customer extends AbstractResource
     private $subscriptions;
     private $invoices;
 
+    protected $owner;
+    protected $source;
+
     /**
      * Get Customer Tags
      *

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -51,6 +51,8 @@ class Invoice extends AbstractResource
     public $line_items = [];
     public $transactions = [];
 
+    public $errors;
+
     public function __construct(array $attr = [], ClientInterface $client = null)
     {
         parent::__construct($attr, $client);

--- a/src/LineItems/OneTime.php
+++ b/src/LineItems/OneTime.php
@@ -10,4 +10,13 @@ class OneTime extends AbstractLineItem
     public $type = 'one_time';
     public $description;
     public $plan_uuid;
+
+    public $subscription_uuid;
+    public $subscription_external_id;
+    public $subscription_set_external_id;
+    public $service_period_start;
+    public $service_period_end;
+    public $cancelled_at;
+    public $prorated;
+    public $account_code;
 }

--- a/src/LineItems/Subscription.php
+++ b/src/LineItems/Subscription.php
@@ -17,4 +17,8 @@ class Subscription extends AbstractLineItem
 
     protected $subscription_uuid;
     public $plan_uuid;
+
+    protected $description;
+    protected $account_code;
+    protected $proration_type;
 }


### PR DESCRIPTION
Dynamic properties are deprecated, so we should add it to Charmogul Resource classes