### PR TITLE
Add missing properties

### DIFF
--- a/src/Customer.php
+++ b/src/Customer.php
@@ -51,36 +51,39 @@ class Customer extends AbstractResource
 
     protected $id;
     protected $uuid;
-    protected $external_id;
-    protected $name;
-    protected $email;
-    protected $company;
-    protected $status;
-    protected $customer_since;
-    protected $attributes;
+
     protected $address;
-    protected $mrr;
     protected $arr;
+    protected $attributes;
+    protected $billing_system_type;
     protected $billing_system_url;
     protected $chartmogul_url;
-    protected $billing_system_type;
+    protected $company;
     protected $currency;
     protected $currency_sign;
+    protected $customer_since;
+    protected $email;
+    protected $external_id;
+    protected $mrr;
+    protected $name;
+    protected $owner;
+    protected $status;
 
     // PATCH = Update a customer
     protected $data_source_uuid;
     protected $data_source_uuids;
     protected $external_ids;
+    protected $free_trial_started_at;
+    protected $lead_created_at;
+    protected $website_url;
+
     protected $city;
     protected $country;
     protected $state;
     protected $zip;
-    protected $lead_created_at;
-    protected $free_trial_started_at;
-    protected $website_url;
 
-    private $subscriptions;
     private $invoices;
+    private $subscriptions;
 
     /**
      * Get Customer Tags

--- a/src/CustomerNote.php
+++ b/src/CustomerNote.php
@@ -41,11 +41,13 @@ class CustomerNote extends AbstractResource
     public const ROOT_KEY = 'entries';
 
     protected $uuid;
-    protected $customer_uuid;
-    protected $type;
-    protected $text;
-    protected $call_duration;
+
     protected $author;
+    protected $author_email;
+    protected $call_duration;
     protected $created_at;
+    protected $customer_uuid;
+    protected $text;
+    protected $type;
     protected $updated_at;
 }

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -30,7 +30,7 @@ class Client implements ClientInterface
     /**
      * @var string
      */
-    private $apiVersion = '6.3.0';
+    private $apiVersion = '6.3.2';
 
     /**
      * @var string

--- a/src/LineItems/AbstractLineItem.php
+++ b/src/LineItems/AbstractLineItem.php
@@ -10,17 +10,19 @@ abstract class AbstractLineItem extends \ChartMogul\Resource\AbstractModel
 {
     protected $uuid;
 
-    public $type;
-    public $amount_in_cents;
-    public $quantity;
-    public $discount_amount_in_cents;
-    public $discount_code;
-    public $tax_amount_in_cents;
-    public $transaction_fees_in_cents;
-    public $transaction_fees_currency;
-    public $discount_description;
-    public $event_order;
     public $external_id;
 
+    public $account_code;
+    public $amount_in_cents;
+    public $discount_amount_in_cents;
+    public $discount_code;
+    public $discount_description;
+    public $event_order;
     public $invoice_uuid;
+    public $plan_uuid;
+    public $quantity;
+    public $tax_amount_in_cents;
+    public $transaction_fees_currency;
+    public $transaction_fees_in_cents;
+    public $type;
 }

--- a/src/LineItems/OneTime.php
+++ b/src/LineItems/OneTime.php
@@ -8,6 +8,6 @@ namespace ChartMogul\LineItems;
 class OneTime extends AbstractLineItem
 {
     public $type = 'one_time';
+
     public $description;
-    public $plan_uuid;
 }

--- a/src/LineItems/Subscription.php
+++ b/src/LineItems/Subscription.php
@@ -8,13 +8,14 @@ namespace ChartMogul\LineItems;
 class Subscription extends AbstractLineItem
 {
     public $type = 'subscription';
-    public $subscription_external_id;
-    public $subscription_set_external_id;
-    public $service_period_start;
-    public $service_period_end;
+
     public $cancelled_at;
     public $prorated;
+    public $proration_type;
+    public $service_period_end;
+    public $service_period_start;
+    public $subscription_external_id;
+    public $subscription_set_external_id;
 
     protected $subscription_uuid;
-    public $plan_uuid;
 }

--- a/src/Metrics/Customers/Activity.php
+++ b/src/Metrics/Customers/Activity.php
@@ -19,14 +19,16 @@ use ChartMogul\Http\ClientInterface;
 class Activity extends AbstractModel
 {
     protected $id;
-    protected $description;
-    protected $type;
-    protected $date;
+
     protected $activity_arr;
     protected $activity_mrr;
     protected $activity_mrr_movement;
     protected $currency;
     protected $currency_sign;
+    protected $date;
+    protected $description;
+    protected $subscription_external_id;
+    protected $type;
 
     /**
      * Returns a list of activities for a given customer.

--- a/src/SubscriptionEvent.php
+++ b/src/SubscriptionEvent.php
@@ -35,15 +35,21 @@ class SubscriptionEvent extends AbstractResource
     public const ROOT_KEY = 'subscription_events';
 
     protected $id;
-    protected $external_id;
-    protected $data_source_uuid;
-    protected $customer_external_id;
-    protected $event_type;
-    protected $event_date;
-    protected $effective_date;
-    protected $currency;
+
     protected $amount_in_cents;
-    protected $subscription_external_id;
-    protected $plan_external_id;
+    protected $created_at;
+    protected $currency;
+    protected $customer_external_id;
+    protected $data_source_uuid;
+    protected $effective_date;
+    protected $errors;
+    protected $event_date;
     protected $event_order;
+    protected $event_type;
+    protected $external_id;
+    protected $plan_external_id;
+    protected $quantity;
+    protected $subscription_external_id;
+    protected $subscription_set_external_id;
+    protected $updated_at;
 }

--- a/tests/Unit/Http/ClientTest.php
+++ b/tests/Unit/Http/ClientTest.php
@@ -10,6 +10,8 @@ use Http\Client\HttpClient;
 
 class ClientTest extends TestCase
 {
+    protected $emptyStream;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Unit/Http/ClientTest.php
+++ b/tests/Unit/Http/ClientTest.php
@@ -37,7 +37,7 @@ class ClientTest extends TestCase
             ->onlyMethods([])
             ->getMock();
 
-        $this->assertEquals("chartmogul-php/6.3.0/PHP-".PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION, $mock->getUserAgent());
+        $this->assertEquals("chartmogul-php/".$mock->getApiVersion()."/PHP-".PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION, $mock->getUserAgent());
     }
 
     public function testGetBasicAuthHeader()

--- a/tests/Unit/InvoiceTest.php
+++ b/tests/Unit/InvoiceTest.php
@@ -129,7 +129,7 @@ class InvoiceTest extends TestCase
         $result = CustomerInvoices::create(
             [
             'customer_uuid' => 'some_id',
-            'invoices' => [['mock' => 'invoice']]
+            'invoices' => [['external_id' => 'some invoice']]
             ], $cmClient
         );
     }

--- a/tests/Unit/Resources/AbstractModelTest.php
+++ b/tests/Unit/Resources/AbstractModelTest.php
@@ -2,6 +2,11 @@
 
 use ChartMogul\Resource\AbstractModel;
 
+class TestClassAbstractModel extends AbstractModel
+{
+    protected $a;
+}
+
 class AbstractModelTest extends \PHPUnit\Framework\TestCase
 {
     public static function provider()
@@ -18,7 +23,7 @@ class AbstractModelTest extends \PHPUnit\Framework\TestCase
      */
     public function testObjectToArray($in, $out)
     {
-        $mock = $this->getMockBuilder(AbstractModel::class)
+        $mock = $this->getMockBuilder(TestClassAbstractModel::class)
             ->setConstructorArgs([$in])
             ->onlyMethods([])
             ->getMock();


### PR DESCRIPTION
[In PHP 9 dynamic properties will become errors](https://php.watch/versions/8.2/dynamic-properties-deprecated) We've received a PR on this topic #127 , but it was not complete unfortunately.

The tests are handy, because they will log these deprecations as long as they cover all requests.

Note that paging traits also need review, because tests are still logging some deprecations there. This change should be fully backwards-compatible, so far it's just deprecations and PHP 9 is not even released yet, so I assume the issue is spamming logs.
