### PR TITLE
Add fields to AbstractModel

### DIFF
--- a/src/Resource/AbstractModel.php
+++ b/src/Resource/AbstractModel.php
@@ -6,6 +6,11 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 abstract class AbstractModel
 {
+    protected $has_more;
+    protected $per_page;
+    protected $page;
+    protected $cursor;
+
     /**
      * @codeCoverageIgnore
      */


### PR DESCRIPTION
Dynamic properties are deprecated in PHP 9. Most of the props are covered in #127 and #128, except of pagination fields.
This PR covers them.