### PR TITLE
Fix static analysis violations with cursor pagination

### DIFF
--- a/src/Resource/AbstractModel.php
+++ b/src/Resource/AbstractModel.php
@@ -4,6 +4,12 @@ namespace ChartMogul\Resource;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
+/** 
+ * @property-read bool $has_more;
+ * @property-read int $per_page;
+ * @property-read int $page;
+ * @property-read string $cursor;
+ */
 abstract class AbstractModel
 {
     protected $has_more;


### PR DESCRIPTION
When using cursor pagination, access to `has_more` and `cursor` are labelled as violations by phpstan or psalm, since those properties are protected on `AbstractModel` although they are readable publicly via `__get()`

sample code 

```php
$cursor = null;
do {
    $filter = ["customer_uuid" => $uuid];
    if ($cursor) {
        $filter["cursor"] = $cursor;
    }

    $collection = \ChartMogul\CustomerInvoices::all($filter);

    foreach ($collection->invoices as $invoice) {
        // do something
    }

    $cursor = $collection->cursor;
} while ($collection->has_more);
```