### PR TITLE
Fix deprecation warnings in PHP 8.4 for dynamic property creation

### DIFF
--- a/src/Resource/AbstractModel.php
+++ b/src/Resource/AbstractModel.php
@@ -19,7 +19,9 @@ abstract class AbstractModel
         foreach ($attributes as $key => $value) {
             // replace property names with dash with underscores
             $key = str_replace('-', '_', $key);
-            $this->$key = $value;
+            if (property_exists($this, $key)) {
+                $this->$key = $value;
+            }
         }
     }
 


### PR DESCRIPTION
I'm not entirely sure if this is a good fix; maybe a better approach would be to create an array for non-existent properties and define magic methods for set/isset.