### PR TITLE
chore: [sc-66255] Update github action/cache version in chartmogul-php repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
The build in Github fails due to deprecation of action/cache v2. It is required to use a newer version.

Story details: https://app.shortcut.com/chartmogul/story/66255