### PR TITLE
Fix deprecation warnings for PHP 8.4 by explicitly marking nullable parameters in method signatures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1', '8.4']
         phpunit-versions: ['9.6']
     steps:
       - uses: actions/checkout@v2

--- a/src/Customer.php
+++ b/src/Customer.php
@@ -223,7 +223,7 @@ class Customer extends AbstractResource
      * @param  ClientInterface|null $client
      * @return bool
      */
-    public static function disconnectSubscriptions($customerUUID, array $data = [], ClientInterface $client = null)
+    public static function disconnectSubscriptions($customerUUID, array $data = [], ?ClientInterface $client = null)
     {
         (new static([], $client))
             ->getClient()


### PR DESCRIPTION
I installed the new version (v6.5.0), and a new call method appeared (https://github.com/chartmogul/chartmogul-php/commit/95a2cc888ae263457e800f9e780da98ec5b5385d#diff-f253bff621d1ee348958b905ed4b8bdedc72a2f6f968224edb025e0a2715c873R226) where PHP 8.4 threw a deprecation warning again. It might be a good idea to include some kind of check for this.