### PR TITLE
Update Subscription Events to properly build from data

### DIFF
--- a/src/Resource/AbstractModel.php
+++ b/src/Resource/AbstractModel.php
@@ -26,7 +26,7 @@ abstract class AbstractModel
     }
 
 
-    private function objectToArray($obj)
+    protected function objectToArray($obj)
     {
         if ($obj instanceof ArrayCollection) {
             $obj = $obj->toArray();
@@ -45,6 +45,7 @@ abstract class AbstractModel
 
         return $data;
     }
+
     /**
      * @codeCoverageIgnore
      * @return             array

--- a/src/SubscriptionEvent.php
+++ b/src/SubscriptionEvent.php
@@ -52,4 +52,19 @@ class SubscriptionEvent extends AbstractResource
     protected $subscription_external_id;
     protected $subscription_set_external_id;
     protected $updated_at;
+
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct(isset($attributes['subscription_event']) ? $attributes['subscription_event'] : $attributes);
+    }
+
+    /**
+     * @inherit
+     */
+    public function toArray()
+    {
+        return [
+            'subscription_event' => $this->objectToArray($this),
+        ];
+    }
 }


### PR DESCRIPTION
An attempt to resolve the [issue](https://github.com/chartmogul/chartmogul-php/issues/141). Because there is no `subcription_event` property, a Subscription Event object was created empty and then being sent to the API. To address that issue I decided to only change SubscriptionEvent class as it's the only endpoint in our API which requires to have `subscription_event` key in the root of the response.