### PR TITLE
Add Tasks API support to PHP Client [sc-66751]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [6.6.0] - 2025-04-25
+- Adds support for Tasks (https://dev.chartmogul.com/reference/tasks)
+
 ## [6.5.0] - 2025-03-18
 - Adds support for disconnecting subscriptions
 - Adds support for transaction fees on transactions

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ All array results are wrapped with [`Doctrine\Common\Collections\ArrayCollection
 
 Available methods in Import API:
 
-### [Data Sources](https://dev.chartmogul.com/docs/data-sources)
+### [Data Sources](https://dev.chartmogul.com/reference/sources/)
 
 **Create Datasources**
 
@@ -399,6 +399,25 @@ $new_opportunity = $customer->createOpportunity([
 ]);
 ```
 
+**List Tasks for a customer**
+```php
+$customer = ChartMogul\Customer::retrieve($customer_uuid);
+$tasks = $customer->tasks([
+  'cursor' => 'aabbccdd...'
+]);
+```
+
+**Create a Task for a customer**
+```php
+$customer = ChartMogul\Customer::retrieve($customer_uuid);
+$new_task = $customer->createTask([
+  'assignee' => 'customer@example.com',
+  'task_details' => 'This is some task details text.',
+  'due_date' => '2025-04-30T00:00:00Z',
+  'completed_at' => '2025-04-20T00:00:00Z',
+]);
+```
+
 ### Customer Notes
 
 **List Customer Notes**
@@ -533,6 +552,45 @@ $updated_opportunity = ChartMogul\Opportunity::update($opportunity_uuid, [
 ```php
 $opportunity = ChartMogul\Opportunity::retrieve($opportunity_uuid)
 $opportunity->destroy();
+```
+
+### Tasks
+
+**List Tasks**
+```php
+$tasks = ChartMogul\Task::all([
+    'customer_uuid' => $customer_uuid,
+    'cursor' => 'aabbccdd...'
+])
+```
+
+**Create a Task**
+```php
+$task = ChartMogul\Task::create([
+    'customer_uuid' => $customer_uuid,
+    'task_details' => 'This is some task details text.',
+    'assignee' => 'customer@example.com',
+    'due_date' => '2025-04-30T00:00:00Z',
+    'completed_at' => '2025-04-20T00:00:00Z',
+])
+```
+
+**Get a Task**
+```php
+$task = ChartMogul\Task::retrieve($task_uuid)
+```
+
+**Update a Task**
+```php
+$updated_task = ChartMogul\Task::update($task_uuid, [
+  'task_details' => 'This is some other task details text.'
+]);
+```
+
+**Delete a Task**
+```php
+$task = ChartMogul\Task::retrieve($task_uuid)
+$task->destroy();
 ```
 
 ### Plans

--- a/src/Customer.php
+++ b/src/Customer.php
@@ -461,4 +461,33 @@ class Customer extends AbstractResource
 
         return new Opportunity($result, $client);
     }
+
+    /**
+     * Find all tasks for a customer.
+     *
+     * @param  array $options
+     * @return CollectionWithCursor
+     */
+    public function tasks(array $options = [])
+    {
+        $client = $this->getClient();
+        $result = $client->send("/v1/tasks", "GET", [$options, "customer_uuid" => $this->uuid]);
+
+        return Task::fromArray($result, $client);
+    }
+
+    /**
+     * Creates a task for a customer.
+     *
+     * @param  array $data
+     * @return Task
+     */
+    public function createTask(array $data = [])
+    {
+        $client = $this->getClient();
+        $data["customer_uuid"] = $this->uuid;
+        $result = $client->send("/v1/tasks", "POST", $data);
+
+        return new Task($result, $client);
+    }
 }

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -30,7 +30,7 @@ class Client implements ClientInterface
     /**
      * @var string
      */
-    private $apiVersion = '6.4.0';
+    private $apiVersion = '6.6.0';
 
     /**
      * @var string

--- a/src/Task.php
+++ b/src/Task.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace ChartMogul;
+
+use ChartMogul\Resource\AbstractResource;
+use ChartMogul\Service\AllTrait;
+use ChartMogul\Service\CreateTrait;
+use ChartMogul\Service\UpdateTrait;
+use ChartMogul\Service\DestroyTrait;
+use ChartMogul\Service\GetTrait;
+use ChartMogul\Service\FromArrayTrait;
+
+/**
+ * @property-read string $uuid
+ * @property-read string $customer_uuid
+ * @property-read string $task_details
+ * @property-read string $assignee
+ * @property-read string $due_date
+ * @property-read string|null $completed_at
+ * @property-read string $created_at
+ * @property-read string $updated_at
+ */
+class Task extends AbstractResource
+{
+    use AllTrait;
+    use CreateTrait;
+    use GetTrait;
+    use DestroyTrait;
+    use UpdateTrait;
+    use FromArrayTrait;
+
+    /**
+     * @ignore
+     */
+    public const RESOURCE_NAME = 'Task';
+    /**
+     * @ignore
+     */
+    public const RESOURCE_PATH = '/v1/tasks';
+    public const RESOURCE_ID = 'uuid';
+    public const ROOT_KEY = 'entries';
+
+    protected $uuid;
+    protected $customer_uuid;
+    protected $task_details;
+    protected $assignee;
+    protected $due_date;
+    protected $completed_at;
+    protected $created_at;
+    protected $updated_at;
+}

--- a/tests/Unit/TaskTest.php
+++ b/tests/Unit/TaskTest.php
@@ -1,0 +1,177 @@
+<?php
+namespace ChartMogul\Tests;
+
+use ChartMogul\Http\Client;
+use ChartMogul\Task;
+use ChartMogul\Resource\Collection;
+use ChartMogul\Exceptions\ChartMogulException;
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Response;
+
+class TaskTest extends TestCase
+{
+    const TASK_JSON = '{
+      "uuid": "00000000-0000-0000-0000-000000000000",
+      "customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
+      "task_details": "This is some task details text.",
+      "assignee": "customer@example.com",
+      "due_date": "2025-04-30T00:00:00Z",
+      "completed_at": "2025-04-20T00:00:00Z",
+      "created_at": "2025-04-01T12:00:00.000Z",
+      "updated_at": "2025-04-01T12:00:00.000Z"
+    }';
+
+    const UPDATED_TASK_JSON= '{
+      "uuid": "00000000-0000-0000-0000-000000000000",
+      "customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
+      "task_details": "This is some other task details text.",
+      "assignee": "customer@example.com",
+      "due_date": "2025-04-30T00:00:00Z",
+      "completed_at": "2025-04-20T00:00:00Z",
+      "created_at": "2025-04-01T12:00:00.000Z",
+      "updated_at": "2025-04-01T12:00:00.000Z"
+    }';
+
+    const LIST_TASKS_JSON = '{
+      "entries": [
+        {
+          "uuid": "00000000-0000-0000-0000-000000000000",
+          "customer_uuid": "cus_00000000-0000-0000-0000-000000000000",
+          "task_details": "This is some task details text.",
+          "assignee": "customer@example.com",
+          "due_date": "2025-04-30T00:00:00Z",
+          "completed_at": "2025-04-20T00:00:00Z",
+          "created_at": "2025-04-01T12:00:00.000Z",
+          "updated_at": "2025-04-01T12:00:00.000Z"
+        }
+      ],
+      "cursor": "cursor==",
+      "has_more": true
+    }';
+
+    public function testListTasks()
+    {
+        $stream = Psr7\stream_for(TaskTest::LIST_TASKS_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $customer_uuid = "cus_00000000-0000-0000-0000-000000000000";
+
+        $result = Task::all(["customer_uuid" => $customer_uuid], $cmClient);
+        $request = $mockClient->getRequests()[0];
+
+        $this->assertEquals("GET", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/tasks", $uri->getPath());
+
+        $this->assertTrue($result[0] instanceof Task);
+        $this->assertEquals("cursor==", $result->cursor);
+        $this->assertEquals(true, $result->has_more);
+    }
+
+    public function testCreateTask()
+    {
+        $stream = Psr7\stream_for(TaskTest::TASK_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $customer_uuid = "cus_00000000-0000-0000-0000-000000000000";
+
+        $result = Task::create(
+            [
+            "customer_uuid" => $customer_uuid,
+            "task_details" => "This is some task details text.",
+            "assignee" => "customer@example.com",
+            "due_date" => "2025-04-30T00:00:00Z",
+            "completed_at" => "2025-04-20T00:00:00Z",
+            ]
+            , $cmClient
+        );
+        $request = $mockClient->getRequests()[0];
+
+        $this->assertEquals("POST", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/tasks", $uri->getPath());
+
+        $this->assertTrue($result instanceof Task);
+        $this->assertEquals("00000000-0000-0000-0000-000000000000", $result->uuid);
+        $this->assertEquals("cus_00000000-0000-0000-0000-000000000000", $result->customer_uuid);
+        $this->assertEquals("This is some task details text.", $result->task_details);
+        $this->assertEquals("customer@example.com", $result->assignee);
+        $this->assertEquals("2025-04-30T00:00:00Z", $result->due_date);
+        $this->assertEquals("2025-04-20T00:00:00Z", $result->completed_at);
+        $this->assertEquals("2025-04-01T12:00:00.000Z", $result->created_at);
+        $this->assertEquals("2025-04-01T12:00:00.000Z", $result->updated_at);
+    }
+
+    public function testRetrieveTask()
+    {
+        $stream = Psr7\stream_for(TaskTest::TASK_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $uuid = "00000000-0000-0000-0000-000000000000";
+
+        $result = Task::retrieve($uuid, $cmClient);
+        $request = $mockClient->getRequests()[0];
+
+        $this->assertEquals("GET", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/tasks/".$uuid, $uri->getPath());
+
+        $this->assertTrue($result instanceof Task);
+        $this->assertEquals("00000000-0000-0000-0000-000000000000", $result->uuid);
+        $this->assertEquals("cus_00000000-0000-0000-0000-000000000000", $result->customer_uuid);
+        $this->assertEquals("This is some task details text.", $result->task_details);
+        $this->assertEquals("customer@example.com", $result->assignee);
+        $this->assertEquals("2025-04-30T00:00:00Z", $result->due_date);
+        $this->assertEquals("2025-04-20T00:00:00Z", $result->completed_at);
+        $this->assertEquals("2025-04-01T12:00:00.000Z", $result->created_at);
+        $this->assertEquals("2025-04-01T12:00:00.000Z", $result->updated_at);
+    }
+
+    public function testUpdateTask()
+    {
+        $stream = Psr7\stream_for(TaskTest::UPDATED_TASK_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $uuid = "00000000-0000-0000-0000-000000000000";
+
+        $result = Task::update(
+            [
+            "uuid" => $uuid,
+            ], [
+            "task_details" => "This is some other task details text.",
+            ], $cmClient
+        );
+        $request = $mockClient->getRequests()[0];
+
+        $this->assertEquals("PATCH", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/tasks/".$uuid, $uri->getPath());
+
+        $this->assertTrue($result instanceof Task);
+        $this->assertEquals("00000000-0000-0000-0000-000000000000", $result->uuid);
+        $this->assertEquals("cus_00000000-0000-0000-0000-000000000000", $result->customer_uuid);
+        $this->assertEquals("This is some other task details text.", $result->task_details);
+        $this->assertEquals("customer@example.com", $result->assignee);
+        $this->assertEquals("2025-04-30T00:00:00Z", $result->due_date);
+        $this->assertEquals("2025-04-20T00:00:00Z", $result->completed_at);
+        $this->assertEquals("2025-04-01T12:00:00.000Z", $result->created_at);
+        $this->assertEquals("2025-04-01T12:00:00.000Z", $result->updated_at);
+    }
+
+    public function testDeleteTask()
+    {
+        $stream = Psr7\stream_for("{}");
+        list($cmClient, $mockClient) = $this->getMockClient(0, [204], $stream);
+
+        $uuid = "00000000-0000-0000-0000-000000000000";
+
+        $result = (new Task(["uuid" => $uuid], $cmClient))->destroy();
+        $request = $mockClient->getRequests()[0];
+
+        $this->assertEquals("DELETE", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/tasks/".$uuid, $uri->getPath());
+
+        $this->assertEquals("{}", $result);
+    }
+}


### PR DESCRIPTION
This PR adds support for the Tasks API to the SDK.

The spec for this project can be found [here](https://www.notion.so/chartmogul/API-for-Tasks-c87a8c8de97d495a92bf7266c49ff6ec).

I'll bump the version in a separate release PR.

## Customer Additions

**List Tasks for a customer**
```php
$customer = ChartMogul\Customer::retrieve($customer_uuid);
$tasks = $customer->tasks([
  'cursor' => 'aabbccdd...'
]);
```

**Create a Task for a customer**
```php
$customer = ChartMogul\Customer::retrieve($customer_uuid);
$new_task = $customer->createTask([
  'assignee' => 'customer@example.com',
  'task_details' => 'This is some task details text.',
  'due_date' => '2025-04-30T00:00:00Z',
  'completed_at' => '2025-04-20T00:00:00Z',
]);
```

## Task Additions

**List Tasks**
```php
$tasks = ChartMogul\Task::all([
    'customer_uuid' => $customer_uuid,
    'cursor' => 'aabbccdd...'
])
```

**Create a Task**
```php
$task = ChartMogul\Task::create([
    'customer_uuid' => $customer_uuid,
    'task_details' => 'This is some task details text.',
    'assignee' => 'customer@example.com',
    'due_date' => '2025-04-30T00:00:00Z',
    'completed_at' => '2025-04-20T00:00:00Z',
])
```

**Get a Task**
```php
$task = ChartMogul\Task::retrieve($task_uuid)
```

**Update a Task**
```php
$updated_task = ChartMogul\Task::update($task_uuid, [
  'task_details' => 'This is some other task details text.'
]);
```

**Delete a Task**
```php
$task = ChartMogul\Task::retrieve($task_uuid)
$task->destroy();
```