### PR TITLE
PHP SDK feature updates

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" stderr="true" stopOnFailure="false" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" stderr="true" stopOnFailure="false" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd">
   <coverage>
     <include>
       <directory suffix=".php">./src</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" stderr="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" stopOnFailure="false" verbose="true" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <filter>
-    <whitelist>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" stderr="true" stopOnFailure="false" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
       <directory suffix=".php">./src</directory>
-    </whitelist>
-  </filter>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="ChartMogul PHP SDK Test Suite">
       <directory suffix="Test.php">./tests</directory>

--- a/src/Account.php
+++ b/src/Account.php
@@ -8,6 +8,7 @@ use ChartMogul\Service\ShowTrait;
 
 /**
  * @codeCoverageIgnore
+ * @property-read      string $id
  * @property-read      string $name
  * @property-read      string $currency
  * @property-read      string $time_zone
@@ -30,6 +31,7 @@ class Account extends AbstractResource
      */
     public const ROOT_KEY = 'account';
 
+    protected $id;
     public $name;
     public $currency;
     public $time_zone;

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -181,6 +181,7 @@ class Client implements ClientInterface
         $request = $request->withUri(
             $request->getUri()->withPath($path)->withQuery($query)
         )
+            ->withProtocolVersion('1.1')
             ->withHeader('Authorization', $this->getBasicAuthHeader())
             ->withHeader('content-type', 'application/json')
             ->withHeader('user-agent', $this->getUserAgent());

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -127,7 +127,7 @@ class Invoice extends AbstractResource
      * @param  ClientInterface|null $client
      * @return self
      */
-    public static function updateStatus(string $uuid, array $data, ?ClientInterface $client = null)
+    public static function updateStatus(string $uuid, array $data, ?ClientInterface $client = null): self
     {
         return (new RequestService($client))
             ->setResourceClass(static::class)
@@ -142,11 +142,11 @@ class Invoice extends AbstractResource
      * @param  ClientInterface|null $client
      * @return self
      */
-    public static function disable(string $uuid, ?ClientInterface $client = null)
+    public static function disable(string $uuid, bool $disabled = true, ?ClientInterface $client = null): self
     {
         return (new RequestService($client))
             ->setResourceClass(static::class)
             ->setResourcePath(static::RESOURCE_PATH . '/:invoice_uuid/disable')
-            ->update(['invoice_uuid' => $uuid], []);
+            ->update(['invoice_uuid' => $uuid], ['disabled' => $disabled]);
     }
 }

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -9,6 +9,8 @@ use ChartMogul\LineItems\Subscription as SubsItem;
 use ChartMogul\Service\AllTrait;
 use ChartMogul\Service\DestroyTrait;
 use ChartMogul\Service\GetTrait;
+use ChartMogul\Service\UpdateTrait;
+use ChartMogul\Service\RequestService;
 use ChartMogul\Resource\AbstractResource;
 use ChartMogul\Transactions\AbstractTransaction;
 use ChartMogul\Transactions\Payment;
@@ -37,6 +39,7 @@ class Invoice extends AbstractResource
     use AllTrait;
     use DestroyTrait;
     use GetTrait;
+    use UpdateTrait;
 
     /**
      * @ignore
@@ -46,6 +49,14 @@ class Invoice extends AbstractResource
      * @ignore
      */
     public const ENTRY_CLASS = Invoice::class;
+    /**
+     * @ignore
+     */
+    public const RESOURCE_NAME = 'Invoice';
+    /**
+     * @ignore
+     */
+    public const RESOURCE_ID = 'invoice_uuid';
     /**
      * @ignore
      */
@@ -106,5 +117,36 @@ class Invoice extends AbstractResource
         } elseif (is_array($tr) && isset($tr['type']) && $tr['type'] === 'refund') {
             $this->transactions[$index] = new Refund($tr);
         }
+    }
+
+    /**
+     * Update the status of an invoice.
+     *
+     * @param  string               $uuid
+     * @param  array                $data  e.g. ['status' => 'void']
+     * @param  ClientInterface|null $client
+     * @return self
+     */
+    public static function updateStatus(string $uuid, array $data, ?ClientInterface $client = null)
+    {
+        return (new RequestService($client))
+            ->setResourceClass(static::class)
+            ->setResourcePath(static::RESOURCE_PATH . '/:invoice_uuid/update-status')
+            ->update(['invoice_uuid' => $uuid], $data);
+    }
+
+    /**
+     * Disable an invoice.
+     *
+     * @param  string               $uuid
+     * @param  ClientInterface|null $client
+     * @return self
+     */
+    public static function disable(string $uuid, ?ClientInterface $client = null)
+    {
+        return (new RequestService($client))
+            ->setResourceClass(static::class)
+            ->setResourcePath(static::RESOURCE_PATH . '/:invoice_uuid/disable')
+            ->update(['invoice_uuid' => $uuid], []);
     }
 }

--- a/src/LineItems/AbstractLineItem.php
+++ b/src/LineItems/AbstractLineItem.php
@@ -25,5 +25,5 @@ abstract class AbstractLineItem extends \ChartMogul\Resource\AbstractModel
     public $transaction_fees_currency;
     public $transaction_fees_in_cents;
     public $type;
-    public $errors;
+    public $errors = null;
 }

--- a/src/LineItems/AbstractLineItem.php
+++ b/src/LineItems/AbstractLineItem.php
@@ -25,4 +25,5 @@ abstract class AbstractLineItem extends \ChartMogul\Resource\AbstractModel
     public $transaction_fees_currency;
     public $transaction_fees_in_cents;
     public $type;
+    public $errors;
 }

--- a/src/Resource/AbstractModel.php
+++ b/src/Resource/AbstractModel.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  * @property-read int $page;
  * @property-read string $cursor;
  */
+#[\AllowDynamicProperties]
 abstract class AbstractModel
 {
     protected $has_more;

--- a/src/Resource/AbstractResource.php
+++ b/src/Resource/AbstractResource.php
@@ -22,6 +22,11 @@ abstract class AbstractResource extends AbstractModel
      */
     public const RESOURCE_NAME = null;
 
+    /**
+     * @ignore
+     */
+    public const ENTRY_KEY = null;
+
 
     /**
      * @var ClientInterface

--- a/src/Service/DestroyWithParamsTrait.php
+++ b/src/Service/DestroyWithParamsTrait.php
@@ -10,7 +10,7 @@ use ChartMogul\Http\ClientInterface;
 trait DestroyWithParamsTrait
 {
     /**
-     * Delete a resource
+     * Delete a resource with flat params (no envelope wrapping needed).
      *
      * @return boolean
      */

--- a/src/Service/GetTrait.php
+++ b/src/Service/GetTrait.php
@@ -12,18 +12,13 @@ trait GetTrait
     /**
      * Get a single resource by UUID.
      *
-     * @return resource
+     * @return self
      */
     public static function retrieve($uuid, ?ClientInterface $client = null, array $query = [])
     {
-        $requestService = (new RequestService($client))
-            ->setResourceClass(static::class);
-
-        if (empty($query)) {
-            return $requestService->get($uuid);
-        }
-
-        return $requestService->getWithQuery($uuid, $query);
+        return (new RequestService($client))
+            ->setResourceClass(static::class)
+            ->get($uuid, $query);
     }
 
     public static function get($uuid, ?ClientInterface $client = null, array $query = [])

--- a/src/Service/RequestService.php
+++ b/src/Service/RequestService.php
@@ -149,8 +149,12 @@ class RequestService
     {
         $client = $this->client;
 
+        if (array_key_exists('subscription_event', $params)) {
+            $params = $params['subscription_event'];
+        }
+
         if (!(array_key_exists('id', $params) || (array_key_exists('data_source_uuid', $params) && array_key_exists('external_id', $params)))) {
-            throw new \ChartMogul\Exceptions\SchemaInvalidException("Param id or params external_id and data_source_uuid required.");
+            throw new \ChartMogul\Exceptions\SchemaInvalidException("Either 'id' or both 'data_source_uuid' and 'external_id' are required.");
         }
 
         $class = $this->resourceClass;
@@ -169,8 +173,12 @@ class RequestService
     {
         $client = $this->client;
 
+        if (array_key_exists('subscription_event', $params)) {
+            $params = $params['subscription_event'];
+        }
+
         if (!(array_key_exists('id', $params) || (array_key_exists('data_source_uuid', $params) && array_key_exists('external_id', $params)))) {
-            throw new \ChartMogul\Exceptions\SchemaInvalidException("Param id or params external_id and data_source_uuid required.");
+            throw new \ChartMogul\Exceptions\SchemaInvalidException("Either 'id' or both 'data_source_uuid' and 'external_id' are required.");
         }
 
         $class = $this->resourceClass;

--- a/src/Service/RequestService.php
+++ b/src/Service/RequestService.php
@@ -149,19 +149,15 @@ class RequestService
     {
         $client = $this->client;
 
-        if (!(array_key_exists('subscription_event', $params))) {
-            throw new \ChartMogul\Exceptions\SchemaInvalidException("Data is not in the good format, 'subscription_event' is missing.");
-        }
-
-        $sub_ev = $params['subscription_event'];
-
-        if (!(array_key_exists('id', $sub_ev) || (array_key_exists('data_source_uuid', $sub_ev) && array_key_exists('external_id', $sub_ev)))) {
+        if (!(array_key_exists('id', $params) || (array_key_exists('data_source_uuid', $params) && array_key_exists('external_id', $params)))) {
             throw new \ChartMogul\Exceptions\SchemaInvalidException("Param id or params external_id and data_source_uuid required.");
         }
 
         $class = $this->resourceClass;
+        $body = ['subscription_event' => $params];
+        $pathData = [];
         $response = $client->setResourceKey($class::RESOURCE_NAME)
-            ->send($this->applyResourcePath($id), 'PATCH', $params);
+            ->send($this->applyResourcePath($pathData), 'PATCH', $body);
 
         return $class::fromArray($response, $this->client);
     }
@@ -173,19 +169,15 @@ class RequestService
     {
         $client = $this->client;
 
-        if (!(array_key_exists('subscription_event', $params))) {
-            throw new \ChartMogul\Exceptions\SchemaInvalidException("Data is not in the good format, 'subscription_event' is missing.");
-        }
-
-        $sub_ev = $params['subscription_event'];
-
-        if (!(array_key_exists('id', $sub_ev) || (array_key_exists('data_source_uuid', $sub_ev) && array_key_exists('external_id', $sub_ev)))) {
+        if (!(array_key_exists('id', $params) || (array_key_exists('data_source_uuid', $params) && array_key_exists('external_id', $params)))) {
             throw new \ChartMogul\Exceptions\SchemaInvalidException("Param id or params external_id and data_source_uuid required.");
         }
 
         $class = $this->resourceClass;
-        $response = $client->setResourceKey($class::RESOURCE_NAME)
-            ->send($this->applyResourcePath($id), 'DELETE', $params);
+        $body = ['subscription_event' => $params];
+        $pathData = [];
+        $client->setResourceKey($class::RESOURCE_NAME)
+            ->send($this->applyResourcePath($pathData), 'DELETE', $body);
 
         return true;
     }

--- a/src/Service/RequestService.php
+++ b/src/Service/RequestService.php
@@ -145,22 +145,35 @@ class RequestService
         return true;
     }
 
-    public function updateWithParams(array $params)
+    /**
+     * Unwrap envelope if present and validate required identification params.
+     *
+     * @param  array  $params
+     * @param  string $envelopeKey
+     * @return array  The normalized (flat) params
+     */
+    private function normalizeEnvelopeParams(array $params, string $envelopeKey): array
     {
-        $client = $this->client;
-
-        if (array_key_exists('subscription_event', $params)) {
-            $params = $params['subscription_event'];
+        if (array_key_exists($envelopeKey, $params)) {
+            $params = $params[$envelopeKey];
         }
 
         if (!(array_key_exists('id', $params) || (array_key_exists('data_source_uuid', $params) && array_key_exists('external_id', $params)))) {
             throw new \ChartMogul\Exceptions\SchemaInvalidException("Either 'id' or both 'data_source_uuid' and 'external_id' are required.");
         }
 
+        return $params;
+    }
+
+    public function updateWithParams(array $params)
+    {
         $class = $this->resourceClass;
-        $body = ['subscription_event' => $params];
+        $envelopeKey = $class::ENTRY_KEY;
+        $params = $this->normalizeEnvelopeParams($params, $envelopeKey);
+
+        $body = [$envelopeKey => $params];
         $pathData = [];
-        $response = $client->setResourceKey($class::RESOURCE_NAME)
+        $response = $this->client->setResourceKey($class::RESOURCE_NAME)
             ->send($this->applyResourcePath($pathData), 'PATCH', $body);
 
         return $class::fromArray($response, $this->client);
@@ -171,39 +184,19 @@ class RequestService
      */
     public function destroyWithParams(array $params)
     {
-        $client = $this->client;
-
-        if (array_key_exists('subscription_event', $params)) {
-            $params = $params['subscription_event'];
-        }
-
-        if (!(array_key_exists('id', $params) || (array_key_exists('data_source_uuid', $params) && array_key_exists('external_id', $params)))) {
-            throw new \ChartMogul\Exceptions\SchemaInvalidException("Either 'id' or both 'data_source_uuid' and 'external_id' are required.");
-        }
-
         $class = $this->resourceClass;
-        $body = ['subscription_event' => $params];
+        $envelopeKey = $class::ENTRY_KEY;
+        $params = $this->normalizeEnvelopeParams($params, $envelopeKey);
+
+        $body = [$envelopeKey => $params];
         $pathData = [];
-        $client->setResourceKey($class::RESOURCE_NAME)
+        $this->client->setResourceKey($class::RESOURCE_NAME)
             ->send($this->applyResourcePath($pathData), 'DELETE', $body);
 
         return true;
     }
 
-    public function get($uuid = null)
-    {
-        $class = $this->resourceClass;
-        $response = $this->client
-            ->setResourceKey($class::RESOURCE_NAME)
-            ->send(
-                $uuid ? $class::RESOURCE_PATH.'/'.$uuid : $class::RESOURCE_PATH,
-                'GET'
-            );
-
-        return $class::fromArray($response, $this->client);
-    }
-
-    public function getWithQuery($uuid = null, $query = [])
+    public function get($uuid = null, array $query = [])
     {
         $class = $this->resourceClass;
         $response = $this->client

--- a/src/Service/ShowTrait.php
+++ b/src/Service/ShowTrait.php
@@ -12,13 +12,19 @@ trait ShowTrait
     /**
      * Show details of current resource.
      *
+     * @param  ClientInterface|null $client
+     * @param  array                $query  Optional query parameters
      * @return resource
      */
-
-    public static function retrieve(?ClientInterface $client = null)
+    public static function retrieve(?ClientInterface $client = null, array $query = [])
     {
-        return (new RequestService($client))
-            ->setResourceClass(static::class)
-            ->get();
+        $requestService = (new RequestService($client))
+            ->setResourceClass(static::class);
+
+        if (empty($query)) {
+            return $requestService->get();
+        }
+
+        return $requestService->getWithQuery(null, $query);
     }
 }

--- a/src/Service/ShowTrait.php
+++ b/src/Service/ShowTrait.php
@@ -14,17 +14,12 @@ trait ShowTrait
      *
      * @param  ClientInterface|null $client
      * @param  array                $query  Optional query parameters
-     * @return resource
+     * @return self
      */
     public static function retrieve(?ClientInterface $client = null, array $query = [])
     {
-        $requestService = (new RequestService($client))
-            ->setResourceClass(static::class);
-
-        if (empty($query)) {
-            return $requestService->get();
-        }
-
-        return $requestService->getWithQuery(null, $query);
+        return (new RequestService($client))
+            ->setResourceClass(static::class)
+            ->get(null, $query);
     }
 }

--- a/src/Service/UpdateWithParamsTrait.php
+++ b/src/Service/UpdateWithParamsTrait.php
@@ -10,7 +10,7 @@ use ChartMogul\Http\ClientInterface;
 trait UpdateWithParamsTrait
 {
     /**
-     * Update a Resource
+     * Update a Resource with flat params (no envelope wrapping needed).
      *
      * @param  array                $params
      * @param  ClientInterface|null $client

--- a/src/SubscriptionEvent.php
+++ b/src/SubscriptionEvent.php
@@ -34,6 +34,11 @@ class SubscriptionEvent extends AbstractResource
      */
     public const ROOT_KEY = 'subscription_events';
 
+    /**
+     * @ignore
+     */
+    public const ENTRY_KEY = 'subscription_event';
+
     protected $id;
 
     protected $amount_in_cents;

--- a/src/SubscriptionEvent.php
+++ b/src/SubscriptionEvent.php
@@ -54,6 +54,11 @@ class SubscriptionEvent extends AbstractResource
     protected $updated_at;
     protected $retracted_event_id;
 
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct(isset($attributes['subscription_event']) ? $attributes['subscription_event'] : $attributes);
+    }
+
     /**
      * @inherit
      */

--- a/src/SubscriptionEvent.php
+++ b/src/SubscriptionEvent.php
@@ -52,11 +52,7 @@ class SubscriptionEvent extends AbstractResource
     protected $subscription_external_id;
     protected $subscription_set_external_id;
     protected $updated_at;
-
-    public function __construct(array $attributes = [])
-    {
-        parent::__construct(isset($attributes['subscription_event']) ? $attributes['subscription_event'] : $attributes);
-    }
+    protected $retracted_event_id;
 
     /**
      * @inherit

--- a/src/Transactions/AbstractTransaction.php
+++ b/src/Transactions/AbstractTransaction.php
@@ -23,4 +23,5 @@ abstract class AbstractTransaction extends AbstractResource
     public $transaction_fees_in_cents;
 
     public $invoice_uuid;
+    public $errors;
 }

--- a/src/Transactions/AbstractTransaction.php
+++ b/src/Transactions/AbstractTransaction.php
@@ -23,5 +23,5 @@ abstract class AbstractTransaction extends AbstractResource
     public $transaction_fees_in_cents;
 
     public $invoice_uuid;
-    public $errors;
+    public $errors = null;
 }

--- a/tests/Unit/AccountTest.php
+++ b/tests/Unit/AccountTest.php
@@ -11,6 +11,7 @@ use ChartMogul\Exceptions\NotFoundException;
 class AccountTest extends TestCase
 {
     const RETRIEVE_ACCOUNT = '{
+    "id": "acct_00000000-0000-0000-0000-000000000000",
     "name": "Example Test Company",
     "currency": "EUR",
     "time_zone": "Europe/Berlin",
@@ -31,9 +32,32 @@ class AccountTest extends TestCase
         $this->assertEquals("/v1/account", $uri->getPath());
 
         $this->assertTrue($result instanceof Account);
-        $this->assertEquals($result->name, "Example Test Company");
-        $this->assertEquals($result->currency, "EUR");
-        $this->assertEquals($result->time_zone, "Europe/Berlin");
-        $this->assertEquals($result->week_start_on, "sunday");
+        $this->assertEquals("acct_00000000-0000-0000-0000-000000000000", $result->id);
+        $this->assertEquals("Example Test Company", $result->name);
+        $this->assertEquals("EUR", $result->currency);
+        $this->assertEquals("Europe/Berlin", $result->time_zone);
+        $this->assertEquals("sunday", $result->week_start_on);
+    }
+
+    public function testRetrieveAccountWithIncludeParams()
+    {
+        $stream = Psr7\stream_for(AccountTest::RETRIEVE_ACCOUNT);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $result = Account::retrieve($cmClient, [
+            'churn_recognition' => true,
+            'churn_when_zero_mrr' => true,
+        ]);
+        $request = $mockClient->getRequests()[0];
+
+        $this->assertEquals("GET", $request->getMethod());
+        $uri = $request->getUri();
+        parse_str($uri->getQuery(), $queryParams);
+        $this->assertEquals('1', $queryParams['churn_recognition']);
+        $this->assertEquals('1', $queryParams['churn_when_zero_mrr']);
+        $this->assertEquals("/v1/account", $uri->getPath());
+
+        $this->assertTrue($result instanceof Account);
+        $this->assertEquals("Example Test Company", $result->name);
     }
 }

--- a/tests/Unit/Http/ClientTest.php
+++ b/tests/Unit/Http/ClientTest.php
@@ -125,6 +125,7 @@ class ClientTest extends TestCase
         $this->assertEquals($request->getHeader('Authorization'), ['auth']);
         $this->assertEquals($request->getHeader('content-type'), ['application/json']);
         $this->assertEquals($request->getMethod(), $method);
+        $this->assertEquals('1.1', $request->getProtocolVersion());
         $this->assertEquals($request->getRequestTarget(), $target);
         $request->getBody()->rewind();
         $this->assertEquals($request->getBody()->getContents(), $rBody);

--- a/tests/Unit/InvoiceTest.php
+++ b/tests/Unit/InvoiceTest.php
@@ -345,4 +345,107 @@ class InvoiceTest extends TestCase
         $this->assertEquals('1', $queryParams['with_disabled']);
         $this->assertEquals("/v1/invoices", $uri->getPath());
     }
+
+    public function testUpdateInvoiceStatus()
+    {
+        $stream = Psr7\stream_for(InvoiceTest::RETRIEVE_INVOICE_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $uuid = 'inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9';
+
+        $result = Invoice::updateStatus($uuid, ['status' => 'void'], $cmClient);
+        $request = $mockClient->getRequests()[0];
+
+        $this->assertEquals("PATCH", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/invoices/".$uuid."/update-status", $uri->getPath());
+        $this->assertTrue($result instanceof Invoice);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertEquals(['status' => 'void'], $body);
+    }
+
+    public function testDisableInvoice()
+    {
+        $stream = Psr7\stream_for(InvoiceTest::RETRIEVE_INVOICE_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $uuid = 'inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9';
+
+        $result = Invoice::disable($uuid, $cmClient);
+        $request = $mockClient->getRequests()[0];
+
+        $this->assertEquals("PATCH", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/invoices/".$uuid."/disable", $uri->getPath());
+        $this->assertTrue($result instanceof Invoice);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertEmpty($body);
+    }
+
+    public function testUpdateInvoice()
+    {
+        $stream = Psr7\stream_for(InvoiceTest::RETRIEVE_INVOICE_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $uuid = 'inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9';
+
+        $result = Invoice::update(
+            ['invoice_uuid' => $uuid],
+            ['currency' => 'EUR'],
+            $cmClient
+        );
+        $request = $mockClient->getRequests()[0];
+
+        $this->assertEquals("PATCH", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/invoices/".$uuid, $uri->getPath());
+        $this->assertTrue($result instanceof Invoice);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertEquals(['currency' => 'EUR'], $body);
+    }
+
+    public function testRetrieveInvoiceLineItemErrors()
+    {
+        $json = '{
+          "uuid": "inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9",
+          "external_id": "INV0001",
+          "date": "2015-11-01T00:00:00.000Z",
+          "due_date": "2015-11-15T00:00:00.000Z",
+          "currency": "USD",
+          "line_items": [
+            {
+              "uuid": "li_d72e6843-5793-41d0-bfdf-0269514c9c56",
+              "external_id": null,
+              "type": "subscription",
+              "amount_in_cents": 5000,
+              "quantity": 1,
+              "errors": {"amount_in_cents": ["must be positive"]}
+            }
+          ],
+          "transactions": [
+            {
+              "uuid": "tr_879d560a-1bec-41bb-986e-665e38a2f7bc",
+              "external_id": null,
+              "type": "payment",
+              "date": "2015-11-05T00:14:23.000Z",
+              "result": "successful",
+              "errors": {"date": ["is in the future"]}
+            }
+          ]
+        }';
+        $stream = Psr7\stream_for($json);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $uuid = 'inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9';
+        $result = Invoice::retrieve($uuid, $cmClient);
+
+        $this->assertIsArray($result->line_items[0]->errors);
+        $this->assertEquals(['must be positive'], $result->line_items[0]->errors['amount_in_cents']);
+
+        $this->assertIsArray($result->transactions[0]->errors);
+        $this->assertEquals(['is in the future'], $result->transactions[0]->errors['date']);
+    }
 }

--- a/tests/Unit/InvoiceTest.php
+++ b/tests/Unit/InvoiceTest.php
@@ -372,7 +372,7 @@ class InvoiceTest extends TestCase
 
         $uuid = 'inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9';
 
-        $result = Invoice::disable($uuid, $cmClient);
+        $result = Invoice::disable($uuid, true, $cmClient);
         $request = $mockClient->getRequests()[0];
 
         $this->assertEquals("PATCH", $request->getMethod());
@@ -381,7 +381,7 @@ class InvoiceTest extends TestCase
         $this->assertTrue($result instanceof Invoice);
 
         $body = json_decode((string) $request->getBody(), true);
-        $this->assertEmpty($body);
+        $this->assertEquals(['disabled' => true], $body);
     }
 
     public function testUpdateInvoice()
@@ -447,5 +447,16 @@ class InvoiceTest extends TestCase
 
         $this->assertIsArray($result->transactions[0]->errors);
         $this->assertEquals(['is in the future'], $result->transactions[0]->errors['date']);
+    }
+
+    public function testUpdateInvoiceMissingResourceId()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('invoice_uuid');
+
+        Invoice::update(
+            ['wrong_key' => 'inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9'],
+            ['currency' => 'EUR']
+        );
     }
 }

--- a/tests/Unit/SubscriptionEventTest.php
+++ b/tests/Unit/SubscriptionEventTest.php
@@ -138,17 +138,35 @@ class SubscriptionEventTest extends TestCase
       "amount_in_cents": 100
     }';
 
+    const DISABLE_SUBSCRIPTION_EVENT = '{
+      "id": 73966836,
+      "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+      "customer_external_id": "scus_023",
+      "subscription_set_external_id": "sub_set_ex_id_1",
+      "subscription_external_id": "sub_0023",
+      "plan_external_id": "p_ex_id_1",
+      "event_date": "2022-04-09T11:17:14Z",
+      "effective_date": "2022-04-09T10:04:13Z",
+      "event_type": "subscription_cancelled",
+      "external_id": "ex_id_1",
+      "created_at": "2022-04-09T11:17:14Z",
+      "updated_at": "2022-04-09T11:17:14Z",
+      "quantity": 1,
+      "currency": "USD",
+      "amount_in_cents": 1000,
+      "retracted_event_id": null
+    }';
+
     public function testBuildSubscriptionEvent()
     {
-        $subscriptionEvent = new SubscriptionEvent(["subscription_event" => [
+        $subscriptionEvent = new SubscriptionEvent([
           "external_id" => "ex_id_1",
           "event_date" => "2022-04-09T11:17:14Z",
           "effective_date" => "2022-04-09T10:04:13Z",
           "event_type" => "subscription_cancelled",
           "data_source_uuid" => "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
           "customer_external_id" => "cus_023",
-          
-        ]]);
+        ]);
         $this->assertEquals("ex_id_1", $subscriptionEvent->external_id);
         $this->assertEquals("2022-04-09T11:17:14Z", $subscriptionEvent->event_date);
         $this->assertEquals("2022-04-09T10:04:13Z", $subscriptionEvent->effective_date);
@@ -235,9 +253,9 @@ class SubscriptionEventTest extends TestCase
         $new_amount = 100;
 
         $result = SubscriptionEvent::updateWithParams(
-            ['subscription_event' => [
+            [
             "id" => $id, 'amount_in_cents' => $new_amount
-            ]],
+            ],
             $cmClient
         );
 
@@ -248,6 +266,11 @@ class SubscriptionEventTest extends TestCase
         $this->assertEquals("/v1/subscription_events", $uri->getPath());
         $this->assertTrue($result instanceof SubscriptionEvent);
         $this->assertEquals($result->amount_in_cents, $new_amount);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertArrayHasKey('subscription_event', $body);
+        $this->assertEquals($id, $body['subscription_event']['id']);
+        $this->assertEquals($new_amount, $body['subscription_event']['amount_in_cents']);
     }
 
     public function testUpdateSubscriptionEventWithDataSourceUuidAndExternalId()
@@ -260,9 +283,9 @@ class SubscriptionEventTest extends TestCase
         $new_amount = 100;
 
         $result = SubscriptionEvent::updateWithParams(
-            ['subscription_event' => [
+            [
             "data_source_uuid" => $data_source_uuid, "external_id" => $external_id, 'amount_in_cents' => $new_amount
-            ]], $cmClient
+            ], $cmClient
         );
 
         $request = $mockClient->getRequests()[0];
@@ -272,6 +295,11 @@ class SubscriptionEventTest extends TestCase
         $this->assertEquals("/v1/subscription_events", $uri->getPath());
         $this->assertTrue($result instanceof SubscriptionEvent);
         $this->assertEquals($result->amount_in_cents, $new_amount);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertArrayHasKey('subscription_event', $body);
+        $this->assertEquals($data_source_uuid, $body['subscription_event']['data_source_uuid']);
+        $this->assertEquals($external_id, $body['subscription_event']['external_id']);
     }
 
     public function testDestroySubscriptionEventWithId()
@@ -279,7 +307,7 @@ class SubscriptionEventTest extends TestCase
         list($cmClient, $mockClient) = $this->getMockClient(0, [204]);
         $id = 73966836;
 
-        $result = SubscriptionEvent::destroyWithParams(['subscription_event' => ["id" => $id]], $cmClient);
+        $result = SubscriptionEvent::destroyWithParams(["id" => $id], $cmClient);
 
         $request = $mockClient->getRequests()[0];
         $this->assertEquals("DELETE", $request->getMethod());
@@ -287,6 +315,10 @@ class SubscriptionEventTest extends TestCase
         $this->assertEquals("", $uri->getQuery());
         $this->assertEquals("/v1/subscription_events", $uri->getPath());
         $this->assertEquals($result, true);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertArrayHasKey('subscription_event', $body);
+        $this->assertEquals($id, $body['subscription_event']['id']);
     }
 
     public function testDestroySubscriptionEventWithDataSourceUuidAndExternalId()
@@ -296,8 +328,8 @@ class SubscriptionEventTest extends TestCase
         $external_id = "ex_id_1";
 
         $result = SubscriptionEvent::destroyWithParams(
-            ['subscription_event' => [
-            "data_source_uuid" => $data_source_uuid, "external_id" => $external_id]
+            [
+            "data_source_uuid" => $data_source_uuid, "external_id" => $external_id
             ], $cmClient
         );
         $request = $mockClient->getRequests()[0];
@@ -306,5 +338,55 @@ class SubscriptionEventTest extends TestCase
         $this->assertEquals("", $uri->getQuery());
         $this->assertEquals("/v1/subscription_events", $uri->getPath());
         $this->assertEquals($result, true);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertArrayHasKey('subscription_event', $body);
+        $this->assertEquals($data_source_uuid, $body['subscription_event']['data_source_uuid']);
+        $this->assertEquals($external_id, $body['subscription_event']['external_id']);
+    }
+
+    public function testDisableSubscriptionEvent()
+    {
+        $stream = Psr7\stream_for(SubscriptionEventTest::DISABLE_SUBSCRIPTION_EVENT);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $id = 73966836;
+
+        $result = SubscriptionEvent::updateWithParams(
+            [
+            "id" => $id,
+            "retracted_event_id" => null,
+            ],
+            $cmClient
+        );
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals("PATCH", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/subscription_events", $uri->getPath());
+        $this->assertTrue($result instanceof SubscriptionEvent);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertArrayHasKey('subscription_event', $body);
+        $this->assertEquals($id, $body['subscription_event']['id']);
+        $this->assertArrayHasKey('retracted_event_id', $body['subscription_event']);
+    }
+
+    public function testUpdateWithParamsMissingRequiredParams()
+    {
+        $this->expectException(\ChartMogul\Exceptions\SchemaInvalidException::class);
+
+        SubscriptionEvent::updateWithParams(
+            ['amount_in_cents' => 100]
+        );
+    }
+
+    public function testDestroyWithParamsMissingRequiredParams()
+    {
+        $this->expectException(\ChartMogul\Exceptions\SchemaInvalidException::class);
+
+        SubscriptionEvent::destroyWithParams(
+            ['amount_in_cents' => 100]
+        );
     }
 }

--- a/tests/Unit/SubscriptionEventTest.php
+++ b/tests/Unit/SubscriptionEventTest.php
@@ -175,6 +175,50 @@ class SubscriptionEventTest extends TestCase
         $this->assertEquals("cus_023", $subscriptionEvent->customer_external_id);
     }
 
+    public function testBuildSubscriptionEventWithWrappedParams()
+    {
+        $subscriptionEvent = new SubscriptionEvent(["subscription_event" => [
+          "external_id" => "ex_id_1",
+          "event_type" => "subscription_cancelled",
+          "data_source_uuid" => "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+        ]]);
+        $this->assertEquals("ex_id_1", $subscriptionEvent->external_id);
+        $this->assertEquals("subscription_cancelled", $subscriptionEvent->event_type);
+    }
+
+    public function testUpdateSubscriptionEventWithWrappedParams()
+    {
+        $stream = Psr7\stream_for(SubscriptionEventTest::UPDATE_SUBSCRIPTION_EVENT);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $result = SubscriptionEvent::updateWithParams(
+            ['subscription_event' => ["id" => 73966836, 'amount_in_cents' => 100]],
+            $cmClient
+        );
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals("PATCH", $request->getMethod());
+        $this->assertTrue($result instanceof SubscriptionEvent);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertArrayHasKey('subscription_event', $body);
+        $this->assertEquals(73966836, $body['subscription_event']['id']);
+    }
+
+    public function testDestroySubscriptionEventWithWrappedParams()
+    {
+        list($cmClient, $mockClient) = $this->getMockClient(0, [204]);
+
+        $result = SubscriptionEvent::destroyWithParams(
+            ['subscription_event' => ["id" => 73966836]],
+            $cmClient
+        );
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals("DELETE", $request->getMethod());
+        $this->assertEquals($result, true);
+    }
+
     public function testAllSubscriptionEvents()
     {
         $stream = Psr7\stream_for(SubscriptionEventTest::ALL_SUBSCRIPTION_EVENT_JSON);


### PR DESCRIPTION
## Summary

Batch of PHP SDK improvements covering new endpoints, interface fixes, bug fixes, and DX improvements.

### Endpoint Support
- **PIP-304**: Expose validation `errors` on line items and transactions
- **PIP-76**: Handle optional `include` params on `v1/account` endpoint (`churn_recognition`, `churn_when_zero_mrr`)
- **PIP-120**: Add account `id` field to Retrieve Account Details response
- Add Invoice `update-status` endpoint support
- Add Invoice `disable` endpoint support
- Add generic Invoice `update` via `UpdateTrait`
- **PIP-306**: Add `data_source_uuid + external_id` query param support for Invoice, LineItem, and Transaction (GET/PATCH/DELETE + `disabled_state`)
- **PIP-135**: Add optional `$client` parameter to `DestroyTrait::destroy()`

### New Resources
- `ChartMogul\LineItem` — standalone resource at `/v1/line_items` for external-id-based operations
- `ChartMogul\Transaction` — standalone resource at `/v1/transactions` for external-id-based operations
- `ExternalIdOperationsTrait` — reusable trait providing `retrieveByExternalId()`, `updateByExternalId()`, `destroyByExternalId()`, `toggleDisabledByExternalId()`

### Interface Fixes
- SubscriptionEvent: accept flat params for create/update/destroy (envelope wrapping handled internally)
- SubscriptionEvent: add `retracted_event_id` for disable support
- Backward compatible — wrapped `['subscription_event' => [...]]` shape still accepted

### Bug Fixes
- **PIP-94**: Add `#[AllowDynamicProperties]` to prevent PHP 8.2+ deprecation warnings
- **PIP-190**: Freeze HTTP protocol version to 1.1

### DX Improvements
- Fix `phpunit.xml.dist` deprecation warnings for PHPUnit 10+ compatibility
- Extract duplicated validation into `normalizeEnvelopeParams()` with `ENTRY_KEY` constant
- Merge `get()`/`getWithQuery()` into single method with optional `$query` param
- Add return type declarations to new Invoice methods
- `Client::send()` now accepts optional 4th `$query` param for non-GET query parameters

## Backwards compatibility review

All changes are **backwards compatible** for public API consumers. No existing code needs modification.

| Change | Assessment |
|--------|-----------|
| `Invoice::update()`, `updateStatus()`, `disable()` | New methods — additive only |
| `Invoice::retrieveByExternalId()`, `updateByExternalId()`, etc. | New methods via `ExternalIdOperationsTrait` — additive |
| `ChartMogul\LineItem`, `ChartMogul\Transaction` (new classes) | Additive — existing `LineItems\*` and `Transactions\*` embedded classes untouched |
| `DestroyTrait::destroy()` gains optional `$client` param | Existing calls `$obj->destroy()` unaffected — defaults to `null` |
| `Client::send()` gains optional 4th `$query` param | Existing callers pass 3 args — unaffected |
| `ClientInterface::send()` gains optional 4th `$query` param | Interface change with default value — existing implementations unaffected |
| `Account::$id` property | New read-only property — additive |
| `SubscriptionEvent::$retracted_event_id` | New property — additive |
| `AbstractLineItem::$errors`, `AbstractTransaction::$errors` | New properties (defaulted to `null`) — additive |
| `ShowTrait::retrieve()` gains optional `$query` param | Existing calls unaffected |
| `updateWithParams()`/`destroyWithParams()` accept flat params | Old wrapped `['subscription_event' => [...]]` format still accepted |
| `SubscriptionEvent` constructor accepts flat params | Old wrapped format still accepted |
| `ENTRY_KEY`, `RESOURCE_NAME`, `RESOURCE_ID` constants | Additive |
| `#[\AllowDynamicProperties]` on `AbstractModel` | Silently ignored on PHP < 8.2 |
| HTTP protocol pinned to 1.1 | Explicit version previously unset; standard behavior |
| `phpunit.xml.dist` schema 9.3 → 11.0 | Dev-only; CI should match installed PHPUnit version |
| `RequestService::getWithQuery()` merged into `get()` | Internal class, not part of public API |
| Exception messages reworded in `SchemaInvalidException` | Only observable if string-matching messages (unlikely) |
| `updateWithParams`/`destroyWithParams` referenced undefined `$id` on main | Bug fix — these were broken before |

## Linear tickets
- [PIP-313](https://linear.app/chartmogul/issue/PIP-313)
- [PIP-304](https://linear.app/chartmogul/issue/PIP-304)
- [PIP-76](https://linear.app/chartmogul/issue/PIP-76)
- [PIP-120](https://linear.app/chartmogul/issue/PIP-120)
- [PIP-94](https://linear.app/chartmogul/issue/PIP-94)
- [PIP-190](https://linear.app/chartmogul/issue/PIP-190)
- [PIP-306](https://linear.app/chartmogul/issue/PIP-306)
- [PIP-135](https://linear.app/chartmogul/issue/PIP-135)

## Test plan
- [x] Unit tests pass for all changed files (Invoice, SubscriptionEvent, Account, Client, LineItem, Transaction)
- [x] Backward compatibility tests for wrapped SubscriptionEvent params
- [x] Request body assertions verify correct envelope wrapping
- [x] Validation error tests for missing required params
- [x] External-id operation tests for Invoice, LineItem, Transaction (GET/PATCH/DELETE + disabled_state)
- [x] Query param assertions on PATCH/DELETE requests verify `data_source_uuid` and `external_id` in query string (not body)

---

## Testing instructions

**Test account**: `WiktorOnboarding` (ID: `acc_d0ea225e-f0f1-40ab-92cf-659dce5f2b76`). To obtain the API key, impersonate `wiktor.plaga@chartmogul.com` in the admin panel and navigate to Profile > API Keys.

> **Prerequisites**: All tests below use a PHP script with the SDK. Set up your API key first:
>
> ```php
> <?php
> require_once __DIR__ . '/vendor/autoload.php';
> ChartMogul\Configuration::getDefaultConfiguration()
>     ->setApiKey('YOUR_API_KEY');
> ```
>
> Save each snippet below as a `.php` file in the SDK root and run with `php <filename>.php`.
> You will need a test account with existing data (customers, invoices, subscription events) for some tests.

---

### PIP-304: Validation errors on line items and transactions

**What changed**: `LineItem` and `Transaction` objects now expose an `errors` property from the API response.

**How to test**:
1. Retrieve an invoice using `validation_type=all` or `validation_type=invalid` to trigger error payloads
2. Verify that `errors` is accessible on line items and transactions

```php
// Replace with a real invoice UUID from your test account
$uuid = 'inv_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX';

$invoice = ChartMogul\Invoice::retrieve($uuid, null, [
    'validation_type' => 'invalid',
]);

echo "Invoice errors: ";
print_r($invoice->errors);

foreach ($invoice->line_items as $li) {
    echo "Line item {$li->uuid} errors: ";
    print_r($li->errors);
}

foreach ($invoice->transactions as $tr) {
    echo "Transaction {$tr->uuid} errors: ";
    print_r($tr->errors);
}
```

**Expected**: `errors` is either `null` (valid) or an associative array of field-level errors. No "undefined property" warnings.

---

### PIP-76: Account include params (churn_recognition, churn_when_zero_mrr)

**What changed**: `Account::retrieve()` now accepts an optional second argument for query parameters.

**How to test**:

```php
// Without params (existing behavior)
$account = ChartMogul\Account::retrieve();
echo "Account name: {$account->name}\n";
echo "Currency: {$account->currency}\n";

// With include params
$account = ChartMogul\Account::retrieve(null, [
    'churn_recognition' => true,
    'churn_when_zero_mrr' => true,
]);
echo "Account name: {$account->name}\n";
```

**Expected**: Both calls succeed. The second call sends `?churn_recognition=1&churn_when_zero_mrr=1` as query params (visible in network/debug logs).

---

### PIP-120: Account ID in retrieve response

**What changed**: The `id` property is now exposed on the `Account` object.

**How to test**:

```php
$account = ChartMogul\Account::retrieve();
echo "Account ID: {$account->id}\n";
echo "Account name: {$account->name}\n";
```

**Expected**: `$account->id` returns a string like `acc_XXXXXXXX-...` (not `null`).

---

### Invoice update-status endpoint

**What changed**: New static method `Invoice::updateStatus($uuid, $data)`.

**How to test**:

```php
$uuid = 'inv_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'; // use a test invoice

$result = ChartMogul\Invoice::updateStatus($uuid, ['status' => 'void']);
echo "Invoice UUID: {$result->uuid}\n";
echo "Class: " . get_class($result) . "\n";
```

**Expected**: Returns an `Invoice` object. The API sends a `PATCH` to `/v1/invoices/{uuid}/update-status` with body `{"status": "void"}`.

---

### Invoice disable endpoint

**What changed**: New static method `Invoice::disable($uuid)`.

**How to test**:

```php
$uuid = 'inv_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'; // use a test invoice

$result = ChartMogul\Invoice::disable($uuid);
echo "Invoice UUID: {$result->uuid}\n";
echo "Disabled: " . ($result->disabled ? 'true' : 'false') . "\n";
```

**Expected**: Returns an `Invoice` object. The API sends a `PATCH` to `/v1/invoices/{uuid}/disable` with body `{"disabled": true}`.

---

### Invoice generic update via UpdateTrait

**What changed**: `Invoice::update()` is now available for general-purpose invoice updates.

**How to test**:

```php
$uuid = 'inv_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX';

$result = ChartMogul\Invoice::update(
    ['invoice_uuid' => $uuid],
    ['currency' => 'EUR']
);
echo "Invoice UUID: {$result->uuid}\n";
echo "Class: " . get_class($result) . "\n";
```

**Expected**: Returns an `Invoice` object. Sends `PATCH /v1/invoices/{uuid}` with body `{"currency": "EUR"}`.

---

### PIP-306: External ID operations (Invoice, LineItem, Transaction)

**What changed**: New `ExternalIdOperationsTrait` provides `retrieveByExternalId()`, `updateByExternalId()`, `destroyByExternalId()`, and `toggleDisabledByExternalId()` for Invoice, LineItem, and Transaction. `Client::send()` now supports query parameters on PATCH/DELETE requests.

**How to test**:

```php
// --- Invoice by external ID ---
$dsUuid = 'ds_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX';
$extId = 'INV0001';

// Retrieve
$invoice = ChartMogul\Invoice::retrieveByExternalId($dsUuid, $extId);
echo "Invoice UUID: {$invoice->uuid}\n";

// Update
$invoice = ChartMogul\Invoice::updateByExternalId($dsUuid, $extId, [
    'currency' => 'EUR',
]);
echo "Updated invoice: {$invoice->uuid}\n";

// Toggle disabled state
$invoice = ChartMogul\Invoice::toggleDisabledByExternalId($dsUuid, $extId, true);
echo "Disabled: " . json_encode($invoice->disabled) . "\n";

// Delete
ChartMogul\Invoice::destroyByExternalId($dsUuid, $extId);
echo "Deleted\n";

// --- LineItem by external ID ---
$liExtId = 'il_XXXXXXXX';

$lineItem = ChartMogul\LineItem::retrieveByExternalId($dsUuid, $liExtId);
echo "LineItem UUID: {$lineItem->uuid}\n";

$lineItem = ChartMogul\LineItem::updateByExternalId($dsUuid, $liExtId, [
    'amount_in_cents' => 5000,
]);
echo "Updated line item: {$lineItem->uuid}\n";

$lineItem = ChartMogul\LineItem::toggleDisabledByExternalId($dsUuid, $liExtId, true);
echo "Disabled: " . json_encode($lineItem->disabled) . "\n";

ChartMogul\LineItem::destroyByExternalId($dsUuid, $liExtId);
echo "Deleted\n";

// --- Transaction by external ID ---
$trExtId = 'ch_XXXXXXXX';

$transaction = ChartMogul\Transaction::retrieveByExternalId($dsUuid, $trExtId);
echo "Transaction UUID: {$transaction->uuid}\n";

$transaction = ChartMogul\Transaction::updateByExternalId($dsUuid, $trExtId, [
    'date' => '2026-01-01T00:00:00Z',
]);
echo "Updated transaction: {$transaction->uuid}\n";

$transaction = ChartMogul\Transaction::toggleDisabledByExternalId($dsUuid, $trExtId, true);
echo "Disabled: " . json_encode($transaction->disabled) . "\n";

ChartMogul\Transaction::destroyByExternalId($dsUuid, $trExtId);
echo "Deleted\n";
```

**Expected**: Each method sends the correct HTTP method to the resource path with `data_source_uuid` and `external_id` as **query parameters** (not in the body). PATCH requests include the update data in the body. DELETE requests have an empty body.

---

### PIP-135: DestroyTrait with custom client

**What changed**: `destroy()` now accepts an optional `?ClientInterface $client` parameter, matching all other traits.

**How to test**:

```php
// Create a custom client with different configuration
$config = new ChartMogul\Configuration('YOUR_API_KEY');
$client = new ChartMogul\Http\Client($config);

$invoice = ChartMogul\Invoice::retrieve('inv_XXXXXXXX', $client);
$invoice->destroy($client); // Pass custom client to destroy
echo "Deleted with custom client\n";
```

**Expected**: The destroy call uses the explicitly provided client rather than the object's default client.

---

### SubscriptionEvent: flat params interface

**What changed**: `updateWithParams()` and `destroyWithParams()` now accept flat params (no `subscription_event` envelope needed). The old wrapped format still works for backward compatibility.

**How to test**:

```php
// NEW flat params style (preferred)
$result = ChartMogul\SubscriptionEvent::updateWithParams([
    'id' => 73966836,  // use a real subscription event ID
    'amount_in_cents' => 500,
]);
echo "Updated event ID: {$result->id}\n";

// OLD wrapped style (still works)
$result = ChartMogul\SubscriptionEvent::updateWithParams([
    'subscription_event' => [
        'id' => 73966836,
        'amount_in_cents' => 600,
    ],
]);
echo "Updated event ID: {$result->id}\n";

// Delete with flat params
ChartMogul\SubscriptionEvent::destroyWithParams([
    'data_source_uuid' => 'ds_XXXX',
    'external_id' => 'ext_XXXX',
]);
echo "Deleted successfully\n";
```

**Expected**: Both flat and wrapped param styles work. No errors or deprecation warnings.

---

### SubscriptionEvent: disable (retracted_event_id)

**What changed**: `retracted_event_id` field is now supported for disabling subscription events.

**How to test**:

```php
$result = ChartMogul\SubscriptionEvent::updateWithParams([
    'id' => 73966836,  // use a real subscription event ID
    'retracted_event_id' => null,
]);
echo "Event ID: {$result->id}\n";
echo "Retracted event ID: " . var_export($result->retracted_event_id, true) . "\n";
```

**Expected**: Returns a `SubscriptionEvent` with `retracted_event_id` accessible (may be `null`).

---

### PIP-94: AllowDynamicProperties (PHP 8.2+)

**What changed**: `#[\AllowDynamicProperties]` attribute added to `AbstractModel` to suppress deprecation warnings.

**How to test**:

```php
// On PHP 8.2+, this should produce NO deprecation warnings
error_reporting(E_ALL);

$account = ChartMogul\Account::retrieve();
echo "Account: {$account->name}\n";

// Retrieve an object that may have new/unknown fields from the API
$events = ChartMogul\SubscriptionEvent::all([]);
echo "Events count: " . count($events) . "\n";
```

**Expected**: No `Deprecated: Creation of dynamic property` warnings on PHP 8.2+. On PHP 7.x/8.0/8.1, the attribute is silently ignored (treated as a comment).

---

### PIP-190: HTTP protocol version frozen to 1.1

**What changed**: All SDK requests now explicitly use HTTP/1.1.

**How to test**:

```php
// Any API call will use HTTP/1.1 — verify by checking response
$account = ChartMogul\Account::retrieve();
echo "Account: {$account->name}\n";
// The request is sent with HTTP/1.1 protocol version
// (verify via packet capture or proxy if needed)
```

**Expected**: SDK requests use HTTP/1.1. No timeout issues related to HTTP/2 chunked transfer encoding.

---

### DX: phpunit.xml.dist fix

**What changed**: Replaced deprecated `<filter><whitelist>` with `<coverage><include>` for PHPUnit 10+.

**How to test**:

```bash
phpunit tests/Unit/
```

**Expected**: No `phpunit.xml.dist` deprecation warnings in test output. All unit tests pass.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
