### PR TITLE
Fix broken ExternalIdOperationsTrait RequestService methods

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -170,10 +170,18 @@ class Client implements ClientInterface
             );
         }
 
+        // Extract query string from path if present (e.g. '/v1/line_items?data_source_uuid=...')
+        $pathParts = explode('?', $path, 2);
+        $path = $pathParts[0];
+        $pathQuery = $pathParts[1] ?? '';
+
         $query = '';
         if ($method === 'GET') {
             $query = http_build_query($data);
             $data = [];
+        }
+        if ($pathQuery) {
+            $query = $query ? $pathQuery . '&' . $query : $pathQuery;
         }
 
         $request = $this->requestFactory

--- a/src/Service/RequestService.php
+++ b/src/Service/RequestService.php
@@ -209,4 +209,82 @@ class RequestService
 
         return $class::fromArray($response, $this->client);
     }
+
+    /**
+     * Retrieve a resource by data_source_uuid and external_id (query-parameter-based).
+     *
+     * @param  array $params  Must contain 'data_source_uuid' and 'external_id'
+     * @return mixed
+     */
+    public function getByExternalId(array $params)
+    {
+        $class = $this->resourceClass;
+        $response = $this->client
+            ->setResourceKey($class::RESOURCE_NAME)
+            ->send($class::RESOURCE_PATH, 'GET', $params);
+
+        return $class::fromArray($response, $this->client);
+    }
+
+    /**
+     * Update a resource by data_source_uuid and external_id (query-parameter-based).
+     *
+     * @param  array $params  Must contain 'data_source_uuid' and 'external_id'
+     * @param  array $data    Fields to update
+     * @return mixed
+     */
+    public function updateByExternalId(array $params, array $data)
+    {
+        $class = $this->resourceClass;
+        $response = $this->client
+            ->setResourceKey($class::RESOURCE_NAME)
+            ->send(
+                $class::RESOURCE_PATH . '?' . http_build_query($params),
+                'PATCH',
+                $data
+            );
+
+        return $class::fromArray($response, $this->client);
+    }
+
+    /**
+     * Delete a resource by data_source_uuid and external_id (query-parameter-based).
+     *
+     * @param  array $params  Must contain 'data_source_uuid' and 'external_id'
+     * @return boolean
+     */
+    public function destroyByExternalId(array $params)
+    {
+        $class = $this->resourceClass;
+        $this->client
+            ->setResourceKey($class::RESOURCE_NAME)
+            ->send(
+                $class::RESOURCE_PATH . '?' . http_build_query($params),
+                'DELETE'
+            );
+
+        return true;
+    }
+
+    /**
+     * PATCH a sub-resource by data_source_uuid and external_id (query-parameter-based).
+     *
+     * @param  string $subresource  e.g. 'disabled_state'
+     * @param  array  $params       Must contain 'data_source_uuid' and 'external_id'
+     * @param  array  $data         Fields to update
+     * @return mixed
+     */
+    public function patchSubresourceByExternalId(string $subresource, array $params, array $data)
+    {
+        $class = $this->resourceClass;
+        $response = $this->client
+            ->setResourceKey($class::RESOURCE_NAME)
+            ->send(
+                $class::RESOURCE_PATH . '/' . $subresource . '?' . http_build_query($params),
+                'PATCH',
+                $data
+            );
+
+        return $class::fromArray($response, $this->client);
+    }
 }

--- a/src/Task.php
+++ b/src/Task.php
@@ -8,6 +8,7 @@ use ChartMogul\Service\CreateTrait;
 use ChartMogul\Service\UpdateTrait;
 use ChartMogul\Service\DestroyTrait;
 use ChartMogul\Service\GetTrait;
+use ChartMogul\Http\ClientInterface;
 use ChartMogul\Service\FromArrayTrait;
 
 /**
@@ -54,6 +55,6 @@ class Task extends AbstractResource
         if (isset($attr['task_uuid'])) {
             $attr['uuid'] = $attr['task_uuid'];
         }
-        parent::__construct($attr);
+        parent::__construct($attr, $client);
     }
 }


### PR DESCRIPTION
## Summary
- Add four missing methods to `RequestService` that `ExternalIdOperationsTrait` was calling: `getByExternalId`, `updateByExternalId`, `destroyByExternalId`, `patchSubresourceByExternalId`
- Fix `Client::send()` to support query parameters in URL paths for non-GET requests
- Without this fix, `LineItem` and `Transaction` external-ID operations were completely non-functional

## Test plan
- [x] Run existing `LineItemTest` and `TransactionTest` external-ID tests
- [x] Verify `retrieveByExternalId`, `updateByExternalId`, `destroyByExternalId`, `toggleDisabledByExternalId` all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)