### PR TITLE
Fix Invoice::disable() and Invoice::updateStatus() URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -922,6 +922,24 @@ $invoices = ChartMogul\Invoice::all([
 $invoice = ChartMogul\Invoice::retrieve('inv_uuid');
 ```
 
+**Update an Invoice Status**
+
+```php
+ChartMogul\Invoice::updateStatus(
+    'ds_35542640-d9f1-11ed-9c30-7727168c74a5', // data_source_uuid
+    'inv_0001',                                  // invoice_external_id
+    ['status' => 'voided']
+);
+```
+
+**Disable an Invoice**
+
+```php
+ChartMogul\Invoice::disable('inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9', true);
+// Re-enable:
+ChartMogul\Invoice::disable('inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9', false);
+```
+
 ### Transactions
 
 **Create a Transaction**

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -120,19 +120,30 @@ class Invoice extends AbstractResource
     }
 
     /**
-     * Update the status of an invoice.
+     * Update the status of an invoice by data_source_uuid and invoice_external_id.
      *
-     * @param  string               $uuid
-     * @param  array                $data  e.g. ['status' => 'void']
+     * @param  string               $dataSourceUuid
+     * @param  string               $invoiceExternalId
+     * @param  array                $data  e.g. ['status' => 'voided']
      * @param  ClientInterface|null $client
      * @return self
      */
-    public static function updateStatus(string $uuid, array $data, ?ClientInterface $client = null): self
-    {
-        return (new RequestService($client))
-            ->setResourceClass(static::class)
-            ->setResourcePath(static::RESOURCE_PATH . '/:invoice_uuid/update-status')
-            ->update(['invoice_uuid' => $uuid], $data);
+    public static function updateStatus(
+        string $dataSourceUuid,
+        string $invoiceExternalId,
+        array $data,
+        ?ClientInterface $client = null
+    ): self {
+        $response = (new static([], $client))
+            ->getClient()
+            ->setResourceKey(static::RESOURCE_NAME)
+            ->send(
+                '/v1/data_sources/' . $dataSourceUuid . '/invoices/' . $invoiceExternalId . '/status',
+                'PUT',
+                $data
+            );
+
+        return static::fromArray($response, $client);
     }
 
     /**
@@ -146,7 +157,7 @@ class Invoice extends AbstractResource
     {
         return (new RequestService($client))
             ->setResourceClass(static::class)
-            ->setResourcePath(static::RESOURCE_PATH . '/:invoice_uuid/disable')
+            ->setResourcePath(static::RESOURCE_PATH . '/:invoice_uuid/disabled_state')
             ->update(['invoice_uuid' => $uuid], ['disabled' => $disabled]);
     }
 }

--- a/tests/Unit/InvoiceTest.php
+++ b/tests/Unit/InvoiceTest.php
@@ -351,18 +351,19 @@ class InvoiceTest extends TestCase
         $stream = Psr7\stream_for(InvoiceTest::RETRIEVE_INVOICE_JSON);
         list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
 
-        $uuid = 'inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9';
+        $dsUuid = 'ds_35542640-d9f1-11ed-9c30-7727168c74a5';
+        $extId = 'inv_0001';
 
-        $result = Invoice::updateStatus($uuid, ['status' => 'void'], $cmClient);
+        $result = Invoice::updateStatus($dsUuid, $extId, ['status' => 'voided'], $cmClient);
         $request = $mockClient->getRequests()[0];
 
-        $this->assertEquals("PATCH", $request->getMethod());
+        $this->assertEquals("PUT", $request->getMethod());
         $uri = $request->getUri();
-        $this->assertEquals("/v1/invoices/".$uuid."/update-status", $uri->getPath());
+        $this->assertEquals("/v1/data_sources/".$dsUuid."/invoices/".$extId."/status", $uri->getPath());
         $this->assertTrue($result instanceof Invoice);
 
         $body = json_decode((string) $request->getBody(), true);
-        $this->assertEquals(['status' => 'void'], $body);
+        $this->assertEquals(['status' => 'voided'], $body);
     }
 
     public function testDisableInvoice()
@@ -377,7 +378,7 @@ class InvoiceTest extends TestCase
 
         $this->assertEquals("PATCH", $request->getMethod());
         $uri = $request->getUri();
-        $this->assertEquals("/v1/invoices/".$uuid."/disable", $uri->getPath());
+        $this->assertEquals("/v1/invoices/".$uuid."/disabled_state", $uri->getPath());
         $this->assertTrue($result instanceof Invoice);
 
         $body = json_decode((string) $request->getBody(), true);


### PR DESCRIPTION
## Summary
- Fix `Invoice::disable()` URL from `/invoices/{uuid}/disable` to `/invoices/{uuid}/disabled_state`
- Fix `Invoice::updateStatus()` from `PATCH /invoices/{uuid}/update-status` to `PUT /data_sources/{ds_uuid}/invoices/{ext_id}/status` (different URL, HTTP method, and identifiers to match the actual API)
- Update tests to match corrected endpoints

## Testing instructions

### Disable an invoice
```php
$invoice = ChartMogul\Invoice::disable(
    'inv_f466e33d-ff2b-4a11-8f85-417eb02157a7',
    true  // disabled
);
// Re-enable:
$invoice = ChartMogul\Invoice::disable(
    'inv_f466e33d-ff2b-4a11-8f85-417eb02157a7',
    false
);
```

### Update an invoice status
```php
$invoice = ChartMogul\Invoice::updateStatus(
    'ds_35542640-d9f1-11ed-9c30-7727168c74a5',  // data_source_uuid
    'inv_0001',                                    // invoice_external_id
    ['status' => 'voided']
);
```

### Run unit tests
```bash
make phpunit tests/Unit/InvoiceTest.php
```

## Backwards compatibility

Breaking change, that was not yet released as the next SDK version, so it will not be treated as such.

`Invoice::updateStatus()` signature changed from `updateStatus(string $uuid, array $data)` to `updateStatus(string $dataSourceUuid, string $invoiceExternalId, array $data)`. Callers must update to provide both identifiers. The previous signature was hitting the wrong endpoint and would not have worked against the real API, so this is a bugfix rather than a behaviour change in practice.

`Invoice::disable()` signature is unchanged — only the underlying URL path was corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)