### PR TITLE
Add UUID-based CRUD and disable operations for LineItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,6 +940,66 @@ ChartMogul\Invoice::disable('inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9', true);
 ChartMogul\Invoice::disable('inv_565c73b2-85b9-49c9-a25e-2b7df6a677c9', false);
 ```
 
+### Line Items
+
+**Retrieve a Line Item**
+
+```php
+$lineItem = ChartMogul\LineItem::retrieve('li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b');
+```
+
+**Update a Line Item**
+
+```php
+$lineItem = ChartMogul\LineItem::update(
+    ['line_item_uuid' => 'li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b'],
+    ['amount_in_cents' => 5000]
+);
+```
+
+**Delete a Line Item**
+
+```php
+$lineItem = new ChartMogul\LineItem(['uuid' => 'li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b']);
+$lineItem->destroy();
+```
+
+**Disable a Line Item**
+
+```php
+ChartMogul\LineItem::disable('li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b', true);
+// Re-enable:
+ChartMogul\LineItem::disable('li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b', false);
+```
+
+**Retrieve a Line Item by External ID**
+
+```php
+$lineItem = ChartMogul\LineItem::retrieveByExternalId(
+    'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba',
+    'il_1Srh42DZd9drsue4U2FQKjsb'
+);
+```
+
+**Update a Line Item by External ID**
+
+```php
+$lineItem = ChartMogul\LineItem::updateByExternalId(
+    'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba',
+    'il_1Srh42DZd9drsue4U2FQKjsb',
+    ['amount_in_cents' => 5000]
+);
+```
+
+**Delete a Line Item by External ID**
+
+```php
+ChartMogul\LineItem::destroyByExternalId(
+    'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba',
+    'il_1Srh42DZd9drsue4U2FQKjsb'
+);
+```
+
 ### Transactions
 
 **Create a Transaction**

--- a/src/LineItem.php
+++ b/src/LineItem.php
@@ -46,49 +46,48 @@ class LineItem extends AbstractResource
     public const ROOT_KEY = 'line_items';
 
     protected $uuid;
+    protected $external_id;
+    protected $type;
+    protected $amount_in_cents;
+    protected $quantity;
+    protected $discount_code;
+    protected $discount_amount_in_cents;
+    protected $tax_amount_in_cents;
+    protected $transaction_fees_in_cents;
+    protected $transaction_fees_currency;
+    protected $account_code;
+    protected $plan_uuid;
+    protected $plan_external_id;
+    protected $discount_description;
+    protected $event_order;
+    protected $invoice_uuid;
+    protected $subscription_uuid;
+    protected $subscription_external_id;
+    protected $subscription_set_external_id;
+    protected $service_period_start;
+    protected $service_period_end;
+    protected $prorated;
+    protected $proration_type;
+    protected $balance_transfer;
+    protected $disabled;
+    protected $disabled_at;
+    protected $disabled_by;
+    protected $user_created;
+    protected $errors;
 
     /**
-     * Disable or enable a line item by UUID.
+     * Toggle the disabled state of a line item by UUID.
      *
      * @param  string               $uuid
      * @param  bool                 $disabled
      * @param  ClientInterface|null $client
      * @return self
      */
-    public static function disable(string $uuid, bool $disabled = true, ?ClientInterface $client = null): self
+    public static function toggleDisabled(string $uuid, bool $disabled = true, ?ClientInterface $client = null): self
     {
         return (new RequestService($client))
             ->setResourceClass(static::class)
             ->setResourcePath(static::RESOURCE_PATH . '/:line_item_uuid/disabled_state')
             ->update(['line_item_uuid' => $uuid], ['disabled' => $disabled]);
     }
-
-    public $external_id;
-    public $type;
-    public $amount_in_cents;
-    public $quantity;
-    public $discount_code;
-    public $discount_amount_in_cents;
-    public $tax_amount_in_cents;
-    public $transaction_fees_in_cents;
-    public $transaction_fees_currency;
-    public $account_code;
-    public $plan_uuid;
-    public $plan_external_id;
-    public $discount_description;
-    public $event_order;
-    public $invoice_uuid;
-    public $subscription_uuid;
-    public $subscription_external_id;
-    public $subscription_set_external_id;
-    public $service_period_start;
-    public $service_period_end;
-    public $prorated;
-    public $proration_type;
-    public $balance_transfer;
-    public $disabled;
-    public $disabled_at;
-    public $disabled_by;
-    public $user_created;
-    public $errors = null;
 }

--- a/src/LineItem.php
+++ b/src/LineItem.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace ChartMogul;
+
+use ChartMogul\Http\ClientInterface;
+use ChartMogul\Resource\AbstractResource;
+use ChartMogul\Service\GetTrait;
+use ChartMogul\Service\UpdateTrait;
+use ChartMogul\Service\DestroyTrait;
+use ChartMogul\Service\ExternalIdOperationsTrait;
+use ChartMogul\Service\RequestService;
+
+/**
+ * Standalone LineItem resource.
+ *
+ * Supports both UUID-based and external-ID-based operations.
+ *
+ * For line items embedded within Invoice responses, the SDK continues to use
+ * LineItems\Subscription and LineItems\OneTime.
+ */
+class LineItem extends AbstractResource
+{
+    use GetTrait;
+    use UpdateTrait;
+    use DestroyTrait;
+    use ExternalIdOperationsTrait;
+
+    /**
+     * @ignore
+     */
+    public const RESOURCE_PATH = '/v1/line_items';
+
+    /**
+     * @ignore
+     */
+    public const RESOURCE_NAME = 'LineItem';
+
+    /**
+     * @ignore
+     */
+    public const RESOURCE_ID = 'line_item_uuid';
+
+    /**
+     * @ignore
+     */
+    public const ROOT_KEY = 'line_items';
+
+    protected $uuid;
+
+    /**
+     * Disable or enable a line item by UUID.
+     *
+     * @param  string               $uuid
+     * @param  bool                 $disabled
+     * @param  ClientInterface|null $client
+     * @return self
+     */
+    public static function disable(string $uuid, bool $disabled = true, ?ClientInterface $client = null): self
+    {
+        return (new RequestService($client))
+            ->setResourceClass(static::class)
+            ->setResourcePath(static::RESOURCE_PATH . '/:line_item_uuid/disabled_state')
+            ->update(['line_item_uuid' => $uuid], ['disabled' => $disabled]);
+    }
+
+    public $external_id;
+    public $type;
+    public $amount_in_cents;
+    public $quantity;
+    public $discount_code;
+    public $discount_amount_in_cents;
+    public $tax_amount_in_cents;
+    public $transaction_fees_in_cents;
+    public $transaction_fees_currency;
+    public $account_code;
+    public $plan_uuid;
+    public $plan_external_id;
+    public $discount_description;
+    public $event_order;
+    public $invoice_uuid;
+    public $subscription_uuid;
+    public $subscription_external_id;
+    public $subscription_set_external_id;
+    public $service_period_start;
+    public $service_period_end;
+    public $prorated;
+    public $proration_type;
+    public $balance_transfer;
+    public $disabled;
+    public $disabled_at;
+    public $disabled_by;
+    public $user_created;
+    public $errors = null;
+}

--- a/src/Service/ExternalIdOperationsTrait.php
+++ b/src/Service/ExternalIdOperationsTrait.php
@@ -22,7 +22,7 @@ trait ExternalIdOperationsTrait
         string $dataSourceUuid,
         string $externalId,
         ?ClientInterface $client = null
-    ) {
+    ): self {
         return (new RequestService($client))
             ->setResourceClass(static::class)
             ->getByExternalId([
@@ -45,7 +45,7 @@ trait ExternalIdOperationsTrait
         string $externalId,
         array $data,
         ?ClientInterface $client = null
-    ) {
+    ): self {
         return (new RequestService($client))
             ->setResourceClass(static::class)
             ->updateByExternalId(
@@ -66,7 +66,7 @@ trait ExternalIdOperationsTrait
         string $dataSourceUuid,
         string $externalId,
         ?ClientInterface $client = null
-    ) {
+    ): bool {
         return (new RequestService($client))
             ->setResourceClass(static::class)
             ->destroyByExternalId([
@@ -89,7 +89,7 @@ trait ExternalIdOperationsTrait
         string $externalId,
         bool $disabled,
         ?ClientInterface $client = null
-    ) {
+    ): self {
         return (new RequestService($client))
             ->setResourceClass(static::class)
             ->patchSubresourceByExternalId(

--- a/src/Service/ExternalIdOperationsTrait.php
+++ b/src/Service/ExternalIdOperationsTrait.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace ChartMogul\Service;
+
+use ChartMogul\Http\ClientInterface;
+
+/**
+ * Shared static methods for resources that support CRUD by data_source_uuid + external_id.
+ * These resources use query-parameter-based lookups (not path-based).
+ */
+trait ExternalIdOperationsTrait
+{
+    /**
+     * Retrieve a resource by data_source_uuid and external_id.
+     *
+     * @param  string               $dataSourceUuid
+     * @param  string               $externalId
+     * @param  ClientInterface|null $client
+     * @return self
+     */
+    public static function retrieveByExternalId(
+        string $dataSourceUuid,
+        string $externalId,
+        ?ClientInterface $client = null
+    ) {
+        return (new RequestService($client))
+            ->setResourceClass(static::class)
+            ->getByExternalId([
+                'data_source_uuid' => $dataSourceUuid,
+                'external_id' => $externalId,
+            ]);
+    }
+
+    /**
+     * Update a resource by data_source_uuid and external_id.
+     *
+     * @param  string               $dataSourceUuid
+     * @param  string               $externalId
+     * @param  array                $data
+     * @param  ClientInterface|null $client
+     * @return self
+     */
+    public static function updateByExternalId(
+        string $dataSourceUuid,
+        string $externalId,
+        array $data,
+        ?ClientInterface $client = null
+    ) {
+        return (new RequestService($client))
+            ->setResourceClass(static::class)
+            ->updateByExternalId(
+                ['data_source_uuid' => $dataSourceUuid, 'external_id' => $externalId],
+                $data
+            );
+    }
+
+    /**
+     * Delete a resource by data_source_uuid and external_id.
+     *
+     * @param  string               $dataSourceUuid
+     * @param  string               $externalId
+     * @param  ClientInterface|null $client
+     * @return boolean
+     */
+    public static function destroyByExternalId(
+        string $dataSourceUuid,
+        string $externalId,
+        ?ClientInterface $client = null
+    ) {
+        return (new RequestService($client))
+            ->setResourceClass(static::class)
+            ->destroyByExternalId([
+                'data_source_uuid' => $dataSourceUuid,
+                'external_id' => $externalId,
+            ]);
+    }
+
+    /**
+     * Toggle disabled state of a resource by data_source_uuid and external_id.
+     *
+     * @param  string               $dataSourceUuid
+     * @param  string               $externalId
+     * @param  bool                 $disabled
+     * @param  ClientInterface|null $client
+     * @return self
+     */
+    public static function toggleDisabledByExternalId(
+        string $dataSourceUuid,
+        string $externalId,
+        bool $disabled,
+        ?ClientInterface $client = null
+    ) {
+        return (new RequestService($client))
+            ->setResourceClass(static::class)
+            ->patchSubresourceByExternalId(
+                'disabled_state',
+                ['data_source_uuid' => $dataSourceUuid, 'external_id' => $externalId],
+                ['disabled' => $disabled]
+            );
+    }
+}

--- a/tests/Unit/LineItemTest.php
+++ b/tests/Unit/LineItemTest.php
@@ -168,13 +168,13 @@ class LineItemTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testDisableByUuid()
+    public function testToggleDisabledByUuid()
     {
         $stream = Psr7\stream_for(self::LINE_ITEM_JSON);
         list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
 
         $uuid = 'li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b';
-        $result = LineItem::disable($uuid, true, $cmClient);
+        $result = LineItem::toggleDisabled($uuid, true, $cmClient);
 
         $request = $mockClient->getRequests()[0];
         $this->assertEquals('PATCH', $request->getMethod());
@@ -184,5 +184,23 @@ class LineItemTest extends TestCase
 
         $body = json_decode((string) $request->getBody(), true);
         $this->assertEquals(['disabled' => true], $body);
+    }
+
+    public function testToggleEnabledByUuid()
+    {
+        $stream = Psr7\stream_for(self::LINE_ITEM_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $uuid = 'li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b';
+        $result = LineItem::toggleDisabled($uuid, false, $cmClient);
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('PATCH', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/line_items/' . $uuid . '/disabled_state', $uri->getPath());
+        $this->assertTrue($result instanceof LineItem);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertEquals(['disabled' => false], $body);
     }
 }

--- a/tests/Unit/LineItemTest.php
+++ b/tests/Unit/LineItemTest.php
@@ -1,0 +1,188 @@
+<?php
+namespace ChartMogul\Tests;
+
+use ChartMogul\LineItem;
+use GuzzleHttp\Psr7;
+
+class LineItemTest extends TestCase
+{
+    const LINE_ITEM_JSON = '{
+        "uuid": "li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b",
+        "external_id": "il_1Srh42DZd9drsue4U2FQKjsb",
+        "type": "subscription",
+        "amount_in_cents": 10000,
+        "quantity": 1,
+        "discount_code": "",
+        "discount_amount_in_cents": 0,
+        "tax_amount_in_cents": 0,
+        "transaction_fees_in_cents": 0,
+        "account_code": "-",
+        "plan_uuid": "pl_c9e8c6fa-c2a0-4b04-a4c5-54ce9f381a54",
+        "plan_external_id": "price_1QK8toDZd9drsue4cpB6eafx",
+        "invoice_uuid": "inv_25256bdf-6d93-48fa-8df3-b5bd8ec7c514",
+        "disabled": false,
+        "disabled_at": null,
+        "disabled_by": null
+    }';
+
+    public function testRetrieveByExternalId()
+    {
+        $stream = Psr7\stream_for(self::LINE_ITEM_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $result = LineItem::retrieveByExternalId(
+            'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba',
+            'il_1Srh42DZd9drsue4U2FQKjsb',
+            $cmClient
+        );
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('GET', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/line_items', $uri->getPath());
+        parse_str($uri->getQuery(), $queryParams);
+        $this->assertEquals('ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba', $queryParams['data_source_uuid']);
+        $this->assertEquals('il_1Srh42DZd9drsue4U2FQKjsb', $queryParams['external_id']);
+        $this->assertTrue($result instanceof LineItem);
+        $this->assertEquals('li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b', $result->uuid);
+    }
+
+    public function testUpdateByExternalId()
+    {
+        $stream = Psr7\stream_for(self::LINE_ITEM_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $result = LineItem::updateByExternalId(
+            'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba',
+            'il_1Srh42DZd9drsue4U2FQKjsb',
+            ['amount_in_cents' => 5000],
+            $cmClient
+        );
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('PATCH', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/line_items', $uri->getPath());
+        parse_str($uri->getQuery(), $queryParams);
+        $this->assertEquals('ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba', $queryParams['data_source_uuid']);
+        $this->assertEquals('il_1Srh42DZd9drsue4U2FQKjsb', $queryParams['external_id']);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertEquals(['amount_in_cents' => 5000], $body);
+        $this->assertTrue($result instanceof LineItem);
+    }
+
+    public function testDestroyByExternalId()
+    {
+        list($cmClient, $mockClient) = $this->getMockClient(0, [204]);
+
+        $result = LineItem::destroyByExternalId(
+            'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba',
+            'il_1Srh42DZd9drsue4U2FQKjsb',
+            $cmClient
+        );
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('DELETE', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/line_items', $uri->getPath());
+        parse_str($uri->getQuery(), $queryParams);
+        $this->assertEquals('ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba', $queryParams['data_source_uuid']);
+        $this->assertEquals('il_1Srh42DZd9drsue4U2FQKjsb', $queryParams['external_id']);
+        $this->assertTrue($result);
+    }
+
+    public function testToggleDisabledByExternalId()
+    {
+        $stream = Psr7\stream_for(self::LINE_ITEM_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $result = LineItem::toggleDisabledByExternalId(
+            'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba',
+            'il_1Srh42DZd9drsue4U2FQKjsb',
+            true,
+            $cmClient
+        );
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('PATCH', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/line_items/disabled_state', $uri->getPath());
+        parse_str($uri->getQuery(), $queryParams);
+        $this->assertEquals('ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba', $queryParams['data_source_uuid']);
+        $this->assertEquals('il_1Srh42DZd9drsue4U2FQKjsb', $queryParams['external_id']);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertEquals(['disabled' => true], $body);
+        $this->assertTrue($result instanceof LineItem);
+    }
+
+    public function testRetrieveByUuid()
+    {
+        $stream = Psr7\stream_for(self::LINE_ITEM_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $uuid = 'li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b';
+        $result = LineItem::retrieve($uuid, $cmClient);
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('GET', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/line_items/' . $uuid, $uri->getPath());
+        $this->assertTrue($result instanceof LineItem);
+        $this->assertEquals($uuid, $result->uuid);
+    }
+
+    public function testUpdateByUuid()
+    {
+        $stream = Psr7\stream_for(self::LINE_ITEM_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $uuid = 'li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b';
+        $result = LineItem::update(
+            ['line_item_uuid' => $uuid],
+            ['amount_in_cents' => 5000],
+            $cmClient
+        );
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('PATCH', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/line_items/' . $uuid, $uri->getPath());
+        $this->assertTrue($result instanceof LineItem);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertEquals(['amount_in_cents' => 5000], $body);
+    }
+
+    public function testDestroyByUuid()
+    {
+        list($cmClient, $mockClient) = $this->getMockClient(0, [204]);
+
+        $result = (new LineItem(['uuid' => 'li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b'], $cmClient))->destroy();
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('DELETE', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/line_items/li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b', $uri->getPath());
+        $this->assertTrue($result);
+    }
+
+    public function testDisableByUuid()
+    {
+        $stream = Psr7\stream_for(self::LINE_ITEM_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $uuid = 'li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b';
+        $result = LineItem::disable($uuid, true, $cmClient);
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('PATCH', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/line_items/' . $uuid . '/disabled_state', $uri->getPath());
+        $this->assertTrue($result instanceof LineItem);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertEquals(['disabled' => true], $body);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `LineItem::retrieve(uuid)` — GET /line_items/{UUID}
- Add `LineItem::update([uuid], data)` — PATCH /line_items/{UUID}
- Add `LineItem->destroy()` — DELETE /line_items/{UUID}
- Add `LineItem::toggleDisabled(uuid)` — PATCH /line_items/{UUID}/disabled_state
- Previously only external-ID-based operations were available
- Includes `ExternalIdOperationsTrait` which defines the external-ID-based operations

## Testing instructions

### Retrieve a line item by UUID
```php
$lineItem = ChartMogul\LineItem::retrieve('li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b');
```

### Update a line item by UUID
```php
$lineItem = ChartMogul\LineItem::update(
    ['line_item_uuid' => 'li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b'],
    ['amount_in_cents' => 5000]
);
```

### Delete a line item by UUID
```php
$lineItem = new ChartMogul\LineItem(['uuid' => 'li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b']);
$lineItem->destroy();
```

### Toggle disabled state of a line item by UUID
```php
$lineItem = ChartMogul\LineItem::toggleDisabled('li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b', true);
// Re-enable:
$lineItem = ChartMogul\LineItem::toggleDisabled('li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b', false);
```

### External-ID-based operations (unchanged)
```php
$lineItem = ChartMogul\LineItem::retrieveByExternalId('ds_xxx', 'il_ext_123');
$lineItem = ChartMogul\LineItem::updateByExternalId('ds_xxx', 'il_ext_123', ['amount_in_cents' => 5000]);
ChartMogul\LineItem::destroyByExternalId('ds_xxx', 'il_ext_123');
$lineItem = ChartMogul\LineItem::toggleDisabledByExternalId('ds_xxx', 'il_ext_123', true);
```

### Run unit tests
```bash
make phpunit tests/Unit/LineItemTest.php
```

## Backwards compatibility
**Fully backwards compatible**. This is a purely additive change — new UUID-based static methods and instance methods are added to `LineItem` alongside the existing `ExternalIdOperationsTrait` methods. No existing signatures are changed.