### PR TITLE
Add UUID-based CRUD and disable operations for Transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1014,6 +1014,64 @@ ChartMogul\Transactions\Refund::create([
 
 The same can be done with Payment class.
 
+**Retrieve a Transaction**
+
+```php
+$transaction = ChartMogul\Transaction::retrieve('tr_0e4de894-83c3-44d8-b406-2b0f89e67fda');
+```
+
+**Update a Transaction**
+
+```php
+$transaction = ChartMogul\Transaction::update(
+    ['transaction_uuid' => 'tr_0e4de894-83c3-44d8-b406-2b0f89e67fda'],
+    ['date' => '2026-02-01T00:00:00Z']
+);
+```
+
+**Delete a Transaction**
+
+```php
+$transaction = new ChartMogul\Transaction(['uuid' => 'tr_0e4de894-83c3-44d8-b406-2b0f89e67fda']);
+$transaction->destroy();
+```
+
+**Disable a Transaction**
+
+```php
+ChartMogul\Transaction::disable('tr_0e4de894-83c3-44d8-b406-2b0f89e67fda', true);
+// Re-enable:
+ChartMogul\Transaction::disable('tr_0e4de894-83c3-44d8-b406-2b0f89e67fda', false);
+```
+
+**Retrieve a Transaction by External ID**
+
+```php
+$transaction = ChartMogul\Transaction::retrieveByExternalId(
+    'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba',
+    'ch_3St2vHDZd9drsue42v3rkVMC'
+);
+```
+
+**Update a Transaction by External ID**
+
+```php
+$transaction = ChartMogul\Transaction::updateByExternalId(
+    'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba',
+    'ch_3St2vHDZd9drsue42v3rkVMC',
+    ['date' => '2026-02-01T00:00:00Z']
+);
+```
+
+**Delete a Transaction by External ID**
+
+```php
+ChartMogul\Transaction::destroyByExternalId(
+    'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba',
+    'ch_3St2vHDZd9drsue42v3rkVMC'
+);
+```
+
 ### Subscriptions
 
 **List Customer Subscriptions**

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -46,34 +46,33 @@ class Transaction extends AbstractResource
     public const ROOT_KEY = 'transactions';
 
     protected $uuid;
+    protected $external_id;
+    protected $type;
+    protected $date;
+    protected $result;
+    protected $amount_in_cents;
+    protected $transaction_fees_in_cents;
+    protected $transaction_fees_currency;
+    protected $invoice_uuid;
+    protected $disabled;
+    protected $disabled_at;
+    protected $disabled_by;
+    protected $user_created;
+    protected $errors;
 
     /**
-     * Disable or enable a transaction by UUID.
+     * Toggle the disabled state of a transaction by UUID.
      *
      * @param  string               $uuid
      * @param  bool                 $disabled
      * @param  ClientInterface|null $client
      * @return self
      */
-    public static function disable(string $uuid, bool $disabled = true, ?ClientInterface $client = null): self
+    public static function toggleDisabled(string $uuid, bool $disabled = true, ?ClientInterface $client = null): self
     {
         return (new RequestService($client))
             ->setResourceClass(static::class)
             ->setResourcePath(static::RESOURCE_PATH . '/:transaction_uuid/disabled_state')
             ->update(['transaction_uuid' => $uuid], ['disabled' => $disabled]);
     }
-
-    public $external_id;
-    public $type;
-    public $date;
-    public $result;
-    public $amount_in_cents;
-    public $transaction_fees_in_cents;
-    public $transaction_fees_currency;
-    public $invoice_uuid;
-    public $disabled;
-    public $disabled_at;
-    public $disabled_by;
-    public $user_created;
-    public $errors = null;
 }

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace ChartMogul;
+
+use ChartMogul\Http\ClientInterface;
+use ChartMogul\Resource\AbstractResource;
+use ChartMogul\Service\GetTrait;
+use ChartMogul\Service\UpdateTrait;
+use ChartMogul\Service\DestroyTrait;
+use ChartMogul\Service\ExternalIdOperationsTrait;
+use ChartMogul\Service\RequestService;
+
+/**
+ * Standalone Transaction resource.
+ *
+ * Supports both UUID-based and external-ID-based operations.
+ *
+ * For transactions embedded within Invoice responses, the SDK continues to use
+ * Transactions\Payment and Transactions\Refund.
+ */
+class Transaction extends AbstractResource
+{
+    use GetTrait;
+    use UpdateTrait;
+    use DestroyTrait;
+    use ExternalIdOperationsTrait;
+
+    /**
+     * @ignore
+     */
+    public const RESOURCE_PATH = '/v1/transactions';
+
+    /**
+     * @ignore
+     */
+    public const RESOURCE_NAME = 'Transaction';
+
+    /**
+     * @ignore
+     */
+    public const RESOURCE_ID = 'transaction_uuid';
+
+    /**
+     * @ignore
+     */
+    public const ROOT_KEY = 'transactions';
+
+    protected $uuid;
+
+    /**
+     * Disable or enable a transaction by UUID.
+     *
+     * @param  string               $uuid
+     * @param  bool                 $disabled
+     * @param  ClientInterface|null $client
+     * @return self
+     */
+    public static function disable(string $uuid, bool $disabled = true, ?ClientInterface $client = null): self
+    {
+        return (new RequestService($client))
+            ->setResourceClass(static::class)
+            ->setResourcePath(static::RESOURCE_PATH . '/:transaction_uuid/disabled_state')
+            ->update(['transaction_uuid' => $uuid], ['disabled' => $disabled]);
+    }
+
+    public $external_id;
+    public $type;
+    public $date;
+    public $result;
+    public $amount_in_cents;
+    public $transaction_fees_in_cents;
+    public $transaction_fees_currency;
+    public $invoice_uuid;
+    public $disabled;
+    public $disabled_at;
+    public $disabled_by;
+    public $user_created;
+    public $errors = null;
+}

--- a/tests/Unit/TransactionTest.php
+++ b/tests/Unit/TransactionTest.php
@@ -1,0 +1,184 @@
+<?php
+namespace ChartMogul\Tests;
+
+use ChartMogul\Transaction;
+use GuzzleHttp\Psr7;
+
+class TransactionTest extends TestCase
+{
+    const TRANSACTION_JSON = '{
+        "uuid": "tr_0e4de894-83c3-44d8-b406-2b0f89e67fda",
+        "external_id": "ch_3St2vHDZd9drsue42v3rkVMC",
+        "type": "payment",
+        "date": "2026-01-24T09:14:29.000Z",
+        "result": "successful",
+        "amount_in_cents": null,
+        "transaction_fees_in_cents": 350,
+        "transaction_fees_currency": "EUR",
+        "invoice_uuid": "inv_25256bdf-6d93-48fa-8df3-b5bd8ec7c514",
+        "disabled": false,
+        "disabled_at": null,
+        "disabled_by": null
+    }';
+
+    public function testRetrieveByExternalId()
+    {
+        $stream = Psr7\stream_for(self::TRANSACTION_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $result = Transaction::retrieveByExternalId(
+            'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba',
+            'ch_3St2vHDZd9drsue42v3rkVMC',
+            $cmClient
+        );
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('GET', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/transactions', $uri->getPath());
+        parse_str($uri->getQuery(), $queryParams);
+        $this->assertEquals('ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba', $queryParams['data_source_uuid']);
+        $this->assertEquals('ch_3St2vHDZd9drsue42v3rkVMC', $queryParams['external_id']);
+        $this->assertTrue($result instanceof Transaction);
+        $this->assertEquals('tr_0e4de894-83c3-44d8-b406-2b0f89e67fda', $result->uuid);
+    }
+
+    public function testUpdateByExternalId()
+    {
+        $stream = Psr7\stream_for(self::TRANSACTION_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $result = Transaction::updateByExternalId(
+            'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba',
+            'ch_3St2vHDZd9drsue42v3rkVMC',
+            ['date' => '2026-02-01T00:00:00Z'],
+            $cmClient
+        );
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('PATCH', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/transactions', $uri->getPath());
+        parse_str($uri->getQuery(), $queryParams);
+        $this->assertEquals('ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba', $queryParams['data_source_uuid']);
+        $this->assertEquals('ch_3St2vHDZd9drsue42v3rkVMC', $queryParams['external_id']);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertEquals(['date' => '2026-02-01T00:00:00Z'], $body);
+        $this->assertTrue($result instanceof Transaction);
+    }
+
+    public function testDestroyByExternalId()
+    {
+        list($cmClient, $mockClient) = $this->getMockClient(0, [204]);
+
+        $result = Transaction::destroyByExternalId(
+            'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba',
+            'ch_3St2vHDZd9drsue42v3rkVMC',
+            $cmClient
+        );
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('DELETE', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/transactions', $uri->getPath());
+        parse_str($uri->getQuery(), $queryParams);
+        $this->assertEquals('ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba', $queryParams['data_source_uuid']);
+        $this->assertEquals('ch_3St2vHDZd9drsue42v3rkVMC', $queryParams['external_id']);
+        $this->assertTrue($result);
+    }
+
+    public function testToggleDisabledByExternalId()
+    {
+        $stream = Psr7\stream_for(self::TRANSACTION_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $result = Transaction::toggleDisabledByExternalId(
+            'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba',
+            'ch_3St2vHDZd9drsue42v3rkVMC',
+            true,
+            $cmClient
+        );
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('PATCH', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/transactions/disabled_state', $uri->getPath());
+        parse_str($uri->getQuery(), $queryParams);
+        $this->assertEquals('ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba', $queryParams['data_source_uuid']);
+        $this->assertEquals('ch_3St2vHDZd9drsue42v3rkVMC', $queryParams['external_id']);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertEquals(['disabled' => true], $body);
+        $this->assertTrue($result instanceof Transaction);
+    }
+
+    public function testRetrieveByUuid()
+    {
+        $stream = Psr7\stream_for(self::TRANSACTION_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $uuid = 'tr_0e4de894-83c3-44d8-b406-2b0f89e67fda';
+        $result = Transaction::retrieve($uuid, $cmClient);
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('GET', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/transactions/' . $uuid, $uri->getPath());
+        $this->assertTrue($result instanceof Transaction);
+        $this->assertEquals($uuid, $result->uuid);
+    }
+
+    public function testUpdateByUuid()
+    {
+        $stream = Psr7\stream_for(self::TRANSACTION_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $uuid = 'tr_0e4de894-83c3-44d8-b406-2b0f89e67fda';
+        $result = Transaction::update(
+            ['transaction_uuid' => $uuid],
+            ['date' => '2026-02-01T00:00:00Z'],
+            $cmClient
+        );
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('PATCH', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/transactions/' . $uuid, $uri->getPath());
+        $this->assertTrue($result instanceof Transaction);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertEquals(['date' => '2026-02-01T00:00:00Z'], $body);
+    }
+
+    public function testDestroyByUuid()
+    {
+        list($cmClient, $mockClient) = $this->getMockClient(0, [204]);
+
+        $result = (new Transaction(['uuid' => 'tr_0e4de894-83c3-44d8-b406-2b0f89e67fda'], $cmClient))->destroy();
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('DELETE', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/transactions/tr_0e4de894-83c3-44d8-b406-2b0f89e67fda', $uri->getPath());
+        $this->assertTrue($result);
+    }
+
+    public function testDisableByUuid()
+    {
+        $stream = Psr7\stream_for(self::TRANSACTION_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $uuid = 'tr_0e4de894-83c3-44d8-b406-2b0f89e67fda';
+        $result = Transaction::disable($uuid, true, $cmClient);
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('PATCH', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/transactions/' . $uuid . '/disabled_state', $uri->getPath());
+        $this->assertTrue($result instanceof Transaction);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertEquals(['disabled' => true], $body);
+    }
+}

--- a/tests/Unit/TransactionTest.php
+++ b/tests/Unit/TransactionTest.php
@@ -18,7 +18,8 @@ class TransactionTest extends TestCase
         "invoice_uuid": "inv_25256bdf-6d93-48fa-8df3-b5bd8ec7c514",
         "disabled": false,
         "disabled_at": null,
-        "disabled_by": null
+        "disabled_by": null,
+        "user_created": false
     }';
 
     public function testRetrieveByExternalId()
@@ -164,13 +165,13 @@ class TransactionTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testDisableByUuid()
+    public function testToggleDisabledByUuid()
     {
         $stream = Psr7\stream_for(self::TRANSACTION_JSON);
         list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
 
         $uuid = 'tr_0e4de894-83c3-44d8-b406-2b0f89e67fda';
-        $result = Transaction::disable($uuid, true, $cmClient);
+        $result = Transaction::toggleDisabled($uuid, true, $cmClient);
 
         $request = $mockClient->getRequests()[0];
         $this->assertEquals('PATCH', $request->getMethod());
@@ -180,5 +181,23 @@ class TransactionTest extends TestCase
 
         $body = json_decode((string) $request->getBody(), true);
         $this->assertEquals(['disabled' => true], $body);
+    }
+
+    public function testReEnableByUuid()
+    {
+        $stream = Psr7\stream_for(self::TRANSACTION_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $uuid = 'tr_0e4de894-83c3-44d8-b406-2b0f89e67fda';
+        $result = Transaction::toggleDisabled($uuid, false, $cmClient);
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('PATCH', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/transactions/' . $uuid . '/disabled_state', $uri->getPath());
+        $this->assertTrue($result instanceof Transaction);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertEquals(['disabled' => false], $body);
     }
 }


### PR DESCRIPTION
## Summary
- Add `Transaction::retrieve(uuid)` — GET /transactions/{UUID}
- Add `Transaction::update([uuid], data)` — PATCH /transactions/{UUID}
- Add `Transaction->destroy()` — DELETE /transactions/{UUID}
- Add `Transaction::toggleDisabled(uuid)` — PATCH /transactions/{UUID}/disabled_state
- Previously only external-ID-based operations were available
- Includes `ExternalIdOperationsTrait` which defines the external-ID-based operations

## Testing instructions

### Retrieve a transaction by UUID
```php
$transaction = ChartMogul\Transaction::retrieve('tr_0e4de894-83c3-44d8-b406-2b0f89e67fda');
```

### Update a transaction by UUID
```php
$transaction = ChartMogul\Transaction::update(
    ['transaction_uuid' => 'tr_0e4de894-83c3-44d8-b406-2b0f89e67fda'],
    ['date' => '2026-02-01T00:00:00Z']
);
```

### Delete a transaction by UUID
```php
$transaction = new ChartMogul\Transaction(['uuid' => 'tr_0e4de894-83c3-44d8-b406-2b0f89e67fda']);
$transaction->destroy();
```

### Toggle disabled state of a transaction by UUID
```php
$transaction = ChartMogul\Transaction::toggleDisabled('tr_0e4de894-83c3-44d8-b406-2b0f89e67fda', true);
// Re-enable:
$transaction = ChartMogul\Transaction::toggleDisabled('tr_0e4de894-83c3-44d8-b406-2b0f89e67fda', false);
```

### External-ID-based operations (unchanged)
```php
$transaction = ChartMogul\Transaction::retrieveByExternalId('ds_xxx', 'ch_ext_123');
$transaction = ChartMogul\Transaction::updateByExternalId('ds_xxx', 'ch_ext_123', ['date' => '2026-02-01T00:00:00Z']);
ChartMogul\Transaction::destroyByExternalId('ds_xxx', 'ch_ext_123');
$transaction = ChartMogul\Transaction::toggleDisabledByExternalId('ds_xxx', 'ch_ext_123', true);
```

### Run unit tests
```bash
make phpunit tests/Unit/TransactionTest.php
```

## Backwards compatibility
✅ **Fully backwards compatible**. This is a purely additive change — new UUID-based static methods and instance methods are added to `Transaction` alongside the existing `ExternalIdOperationsTrait` methods. No existing signatures are changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)