### PR TITLE
Add SubscriptionEvent::disable() endpoint

### DIFF
--- a/src/SubscriptionEvent.php
+++ b/src/SubscriptionEvent.php
@@ -8,6 +8,7 @@ use ChartMogul\Service\AllTrait;
 use ChartMogul\Service\CreateTrait;
 use ChartMogul\Service\UpdateWithParamsTrait;
 use ChartMogul\Service\DestroyWithParamsTrait;
+use ChartMogul\Service\RequestService;
 use ChartMogul\Resource\Collection;
 use ChartMogul\Resource\SubscriptionEventCollection;
 use ChartMogul\Resource\MetaCollection;
@@ -58,6 +59,31 @@ class SubscriptionEvent extends AbstractResource
     protected $subscription_set_external_id;
     protected $updated_at;
     protected $retracted_event_id;
+    protected $disabled;
+    protected $disabled_at;
+    protected $disabled_by;
+
+    /**
+     * Disable or enable a subscription event by ID.
+     *
+     * @param  int|string           $id
+     * @param  bool                 $disabled
+     * @param  ClientInterface|null $client
+     * @return self
+     */
+    public static function disable($id, bool $disabled = true, ?ClientInterface $client = null): self
+    {
+        $response = (new static([], $client))
+            ->getClient()
+            ->setResourceKey(static::RESOURCE_NAME)
+            ->send(
+                static::RESOURCE_PATH . '/' . $id . '/disabled_state',
+                'PATCH',
+                ['disabled' => $disabled]
+            );
+
+        return static::fromArray($response, $client);
+    }
 
     public function __construct(array $attributes = [])
     {

--- a/src/SubscriptionEvent.php
+++ b/src/SubscriptionEvent.php
@@ -73,16 +73,10 @@ class SubscriptionEvent extends AbstractResource
      */
     public static function disable($id, bool $disabled = true, ?ClientInterface $client = null): self
     {
-        $response = (new static([], $client))
-            ->getClient()
-            ->setResourceKey(static::RESOURCE_NAME)
-            ->send(
-                static::RESOURCE_PATH . '/' . $id . '/disabled_state',
-                'PATCH',
-                ['disabled' => $disabled]
-            );
-
-        return static::fromArray($response, $client);
+        return (new RequestService($client))
+            ->setResourceClass(static::class)
+            ->setResourcePath(static::RESOURCE_PATH . '/:id/disabled_state')
+            ->update(['id' => $id], ['disabled' => $disabled]);
     }
 
     public function __construct(array $attributes = [])

--- a/tests/Unit/SubscriptionEventTest.php
+++ b/tests/Unit/SubscriptionEventTest.php
@@ -433,4 +433,22 @@ class SubscriptionEventTest extends TestCase
             ['amount_in_cents' => 100]
         );
     }
+
+    public function testDisable()
+    {
+        $stream = Psr7\stream_for(self::RETRIEVE_SUBSCRIPTION_EVENT);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $id = 73966836;
+        $result = SubscriptionEvent::disable($id, true, $cmClient);
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('PATCH', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/subscription_events/' . $id . '/disabled_state', $uri->getPath());
+        $this->assertTrue($result instanceof SubscriptionEvent);
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertEquals(['disabled' => true], $body);
+    }
 }


### PR DESCRIPTION
## Summary
- Add `SubscriptionEvent::disable(id, disabled)` — PATCH /subscription_events/{ID}/disabled_state
- Add `disabled`, `disabled_at`, `disabled_by` properties to the model
- Uses `RequestService` for proper client handling (SubscriptionEvent has a custom constructor that does not accept a client parameter)

## Testing instructions

### Disable a subscription event
```php
$event = ChartMogul\SubscriptionEvent::disable(73966836, true);
```

### Re-enable a subscription event
```php
$event = ChartMogul\SubscriptionEvent::disable(73966836, false);
```

### Read disabled state from a subscription event
```php
$events = ChartMogul\SubscriptionEvent::all();
foreach ($events->subscription_events as $event) {
    echo $event->disabled;     // bool
    echo $event->disabled_at;  // string|null
    echo $event->disabled_by;  // string|null
}
```

### Run unit tests
```bash
make phpunit tests/Unit/SubscriptionEventTest.php
```

## Backwards compatibility
✅ **Fully backwards compatible**. Adds a new static method `disable()` and three new read-only properties. No existing methods or properties are changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)