### PR TITLE
Add Customer attribute retrieval and by-email endpoints

### DIFF
--- a/src/Customer.php
+++ b/src/Customer.php
@@ -444,6 +444,58 @@ class Customer extends AbstractResource
     }
 
     /**
+     * Retrieve a customer's tags and custom attributes.
+     *
+     * @return array
+     */
+    public function retrieveAttributes()
+    {
+        $result = $this->getClient()
+            ->send('/v1/customers/' . $this->uuid . '/attributes', 'GET');
+
+        $this->attributes = $result;
+        return $result;
+    }
+
+    /**
+     * Add tags to customers by email address.
+     *
+     * @param  string               $email
+     * @param  array                $tags
+     * @param  ClientInterface|null $client
+     * @return array
+     */
+    public static function addTagsByEmail(string $email, array $tags, ?ClientInterface $client = null)
+    {
+        return (new static([], $client))
+            ->getClient()
+            ->setResourceKey(static::RESOURCE_NAME)
+            ->send('/v1/customers/attributes/tags', 'POST', [
+                'email' => $email,
+                'tags' => $tags,
+            ]);
+    }
+
+    /**
+     * Add custom attributes to customers by email address.
+     *
+     * @param  string               $email
+     * @param  array                $custom
+     * @param  ClientInterface|null $client
+     * @return array
+     */
+    public static function addCustomAttributesByEmail(string $email, array $custom, ?ClientInterface $client = null)
+    {
+        return (new static([], $client))
+            ->getClient()
+            ->setResourceKey(static::RESOURCE_NAME)
+            ->send('/v1/customers/attributes/custom', 'POST', [
+                'email' => $email,
+                'custom' => $custom,
+            ]);
+    }
+
+    /**
      * Find a Customer Subscriptions
      *
      * @param      array $options

--- a/tests/Unit/CustomerTest.php
+++ b/tests/Unit/CustomerTest.php
@@ -698,4 +698,58 @@ class CustomerTest extends TestCase
         $this->assertEquals("2025-04-01T12:00:00.000Z", $result->created_at);
         $this->assertEquals("2025-04-01T12:00:00.000Z", $result->updated_at);
     }
+
+    public function testRetrieveAttributes()
+    {
+        $attributesJson = '{"tags": ["important", "Prio1"], "custom": {"channel": "Facebook", "age": 25}}';
+        $stream = Psr7\stream_for($attributesJson);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $customer_uuid = "cus_00000000-0000-0000-0000-000000000000";
+        $result = (new Customer(["uuid" => $customer_uuid], $cmClient))->retrieveAttributes();
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals("GET", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/customers/" . $customer_uuid . "/attributes", $uri->getPath());
+        $this->assertArrayHasKey('tags', $result);
+        $this->assertArrayHasKey('custom', $result);
+    }
+
+    public function testAddTagsByEmail()
+    {
+        $tagsJson = '{"tags": ["important", "Prio1"]}';
+        $stream = Psr7\stream_for($tagsJson);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $result = Customer::addTagsByEmail('test@example.com', ['important', 'Prio1'], $cmClient);
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals("POST", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/customers/attributes/tags", $uri->getPath());
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertEquals('test@example.com', $body['email']);
+        $this->assertEquals(['important', 'Prio1'], $body['tags']);
+    }
+
+    public function testAddCustomAttributesByEmail()
+    {
+        $customJson = '{"custom": [{"type": "String", "key": "channel", "value": "Facebook"}]}';
+        $stream = Psr7\stream_for($customJson);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $custom = [['type' => 'String', 'key' => 'channel', 'value' => 'Facebook']];
+        $result = Customer::addCustomAttributesByEmail('test@example.com', $custom, $cmClient);
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals("POST", $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals("/v1/customers/attributes/custom", $uri->getPath());
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertEquals('test@example.com', $body['email']);
+        $this->assertCount(1, $body['custom']);
+    }
 }

--- a/tests/Unit/CustomerTest.php
+++ b/tests/Unit/CustomerTest.php
@@ -732,6 +732,8 @@ class CustomerTest extends TestCase
         $body = json_decode((string) $request->getBody(), true);
         $this->assertEquals('test@example.com', $body['email']);
         $this->assertEquals(['important', 'Prio1'], $body['tags']);
+
+        $this->assertEquals(['important', 'Prio1'], $result['tags']);
     }
 
     public function testAddCustomAttributesByEmail()
@@ -751,5 +753,10 @@ class CustomerTest extends TestCase
         $body = json_decode((string) $request->getBody(), true);
         $this->assertEquals('test@example.com', $body['email']);
         $this->assertCount(1, $body['custom']);
+
+        $this->assertCount(1, $result['custom']);
+        $this->assertEquals('String', $result['custom'][0]['type']);
+        $this->assertEquals('channel', $result['custom'][0]['key']);
+        $this->assertEquals('Facebook', $result['custom'][0]['value']);
     }
 }


### PR DESCRIPTION
## Summary
- Add `Customer->retrieveAttributes()` — GET /customers/{UUID}/attributes
- Add `Customer::addTagsByEmail(email, tags)` — POST /customers/attributes/tags
- Add `Customer::addCustomAttributesByEmail(email, custom)` — POST /customers/attributes/custom

## Testing instructions

### Retrieve a customer's tags and custom attributes
```php
$customer = ChartMogul\Customer::retrieve('cus_de305d54-75b4-431b-adb2-eb6b9e546012');
$attributes = $customer->retrieveAttributes();
// $attributes['tags']   => ['important', 'Prio1']
// $attributes['custom'] => ['channel' => 'Facebook', 'age' => 25]
```

### Add tags to customers by email
```php
$result = ChartMogul\Customer::addTagsByEmail(
    'adam@smith.com',
    ['important', 'Prio1']
);
// $result['tags'] => ['important', 'Prio1']
```

### Add custom attributes to customers by email
```php
$result = ChartMogul\Customer::addCustomAttributesByEmail(
    'adam@smith.com',
    [
        ['type' => 'String', 'key' => 'channel', 'value' => 'Facebook'],
        ['type' => 'Integer', 'key' => 'age', 'value' => 25],
    ]
);
```

### Run unit tests
```bash
make phpunit tests/Unit/CustomerTest.php
```

## Backwards compatibility
✅ **Fully backwards compatible**. Adds one new instance method (`retrieveAttributes`) and two new static methods (`addTagsByEmail`, `addCustomAttributesByEmail`). No existing methods or properties are changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)