### PR TITLE
Add bulk import endpoints

### DIFF
--- a/src/BulkImport.php
+++ b/src/BulkImport.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace ChartMogul;
+
+use ChartMogul\Http\ClientInterface;
+use ChartMogul\Resource\AbstractResource;
+
+class BulkImport extends AbstractResource
+{
+    /**
+     * @ignore
+     */
+    public const RESOURCE_NAME = 'BulkImport';
+
+    protected $id;
+    protected $data_source_uuid;
+    protected $status;
+    protected $created_at;
+    protected $updated_at;
+    protected $error;
+
+    /**
+     * Import data in bulk for a data source.
+     *
+     * @param  string               $dataSourceUuid
+     * @param  array                $data  Bulk import payload (customers, plans, invoices, etc.)
+     * @param  ClientInterface|null $client
+     * @return self
+     */
+    public static function create(string $dataSourceUuid, array $data, ?ClientInterface $client = null): self
+    {
+        $response = (new static([], $client))
+            ->getClient()
+            ->setResourceKey(static::RESOURCE_NAME)
+            ->send(
+                '/v1/data_sources/' . $dataSourceUuid . '/json_imports',
+                'POST',
+                $data
+            );
+
+        return new static($response, $client);
+    }
+
+    /**
+     * Track the status of a bulk import.
+     *
+     * @param  string               $dataSourceUuid
+     * @param  string               $importId
+     * @param  ClientInterface|null $client
+     * @return self
+     */
+    public static function retrieve(string $dataSourceUuid, string $importId, ?ClientInterface $client = null): self
+    {
+        $response = (new static([], $client))
+            ->getClient()
+            ->setResourceKey(static::RESOURCE_NAME)
+            ->send(
+                '/v1/data_sources/' . $dataSourceUuid . '/json_imports/' . $importId,
+                'GET'
+            );
+
+        return new static($response, $client);
+    }
+}

--- a/src/DataSource.php
+++ b/src/DataSource.php
@@ -50,24 +50,4 @@ class DataSource extends AbstractResource
     protected $invoice_handling_setting;
 
     public $name;
-
-    /**
-     * Upload CSV data to a data source.
-     *
-     * @param  string               $dataSourceUuid
-     * @param  array                $data  Upload payload
-     * @param  ClientInterface|null $client
-     * @return array
-     */
-    public static function upload(string $dataSourceUuid, array $data, ?ClientInterface $client = null)
-    {
-        return (new static([], $client))
-            ->getClient()
-            ->setResourceKey(static::RESOURCE_NAME)
-            ->send(
-                '/v1/data_sources/' . $dataSourceUuid . '/uploads',
-                'POST',
-                $data
-            );
-    }
 }

--- a/src/DataSource.php
+++ b/src/DataSource.php
@@ -50,4 +50,24 @@ class DataSource extends AbstractResource
     protected $invoice_handling_setting;
 
     public $name;
+
+    /**
+     * Upload CSV data to a data source.
+     *
+     * @param  string               $dataSourceUuid
+     * @param  array                $data  Upload payload
+     * @param  ClientInterface|null $client
+     * @return array
+     */
+    public static function upload(string $dataSourceUuid, array $data, ?ClientInterface $client = null)
+    {
+        return (new static([], $client))
+            ->getClient()
+            ->setResourceKey(static::RESOURCE_NAME)
+            ->send(
+                '/v1/data_sources/' . $dataSourceUuid . '/uploads',
+                'POST',
+                $data
+            );
+    }
 }

--- a/tests/Unit/BulkImportTest.php
+++ b/tests/Unit/BulkImportTest.php
@@ -1,0 +1,47 @@
+<?php
+namespace ChartMogul\Tests;
+
+use ChartMogul\BulkImport;
+use GuzzleHttp\Psr7;
+
+class BulkImportTest extends TestCase
+{
+    const BULK_IMPORT_JSON = '{
+        "id": "ds_import_1",
+        "data_source_uuid": "ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba",
+        "status": "queued",
+        "created_at": "2024-01-01T00:00:00.000Z",
+        "updated_at": "2024-01-01T00:00:00.000Z"
+    }';
+
+    public function testCreate()
+    {
+        $stream = Psr7\stream_for(self::BULK_IMPORT_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $dsUuid = 'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba';
+        $result = BulkImport::create($dsUuid, ['customers' => []], $cmClient);
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('POST', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/data_sources/' . $dsUuid . '/json_imports', $uri->getPath());
+        $this->assertTrue($result instanceof BulkImport);
+    }
+
+    public function testRetrieve()
+    {
+        $stream = Psr7\stream_for(self::BULK_IMPORT_JSON);
+        list($cmClient, $mockClient) = $this->getMockClient(0, [200], $stream);
+
+        $dsUuid = 'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba';
+        $importId = 'ds_import_1';
+        $result = BulkImport::retrieve($dsUuid, $importId, $cmClient);
+
+        $request = $mockClient->getRequests()[0];
+        $this->assertEquals('GET', $request->getMethod());
+        $uri = $request->getUri();
+        $this->assertEquals('/v1/data_sources/' . $dsUuid . '/json_imports/' . $importId, $uri->getPath());
+        $this->assertTrue($result instanceof BulkImport);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `BulkImport::create(dsUuid, data)` — POST /data_sources/{UUID}/json_imports
- Add `BulkImport::retrieve(dsUuid, importId)` — GET /data_sources/{UUID}/json_imports/{ID}

## Testing instructions

### Import data in bulk
```php
$import = ChartMogul\BulkImport::create(
    'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba',
    [
        'customers' => [
            [
                'external_id' => 'cus_001',
                'name' => 'Adam Smith',
                'email' => 'adam@smith.com',
            ],
        ],
        'invoices' => [
            // ...
        ],
    ]
);
// $import->id     => 'ds_import_1'
// $import->status => 'queued'
```

### Track import status
```php
$import = ChartMogul\BulkImport::retrieve(
    'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba',
    'ds_import_1'
);
// $import->status => 'completed'
```

### Run unit tests
```bash
make phpunit tests/Unit/BulkImportTest.php
```

## Backwards compatibility
✅ **Fully backwards compatible**. Introduces a new `BulkImport` class. No existing classes, methods, or properties are changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)