### PR TITLE
Fix bin/release.sh grep -oP failure on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Verify version matches tag
         run: |
-          FILE_VERSION="v$(grep -oP "apiVersion = '\K[^']+" src/Http/Client.php)"
+          FILE_VERSION="v$(sed -n "s/.*apiVersion = '\([^']*\)'.*/\1/p" src/Http/Client.php)"
           if [ "$FILE_VERSION" != "$GITHUB_REF_NAME" ]; then
             echo "::error::Client.php version ($FILE_VERSION) does not match tag ($GITHUB_REF_NAME)"
             exit 1

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -97,7 +97,7 @@ fi
 
 # --- Bump version ------------------------------------------------------------
 
-CURRENT_VERSION=$(grep -oP "apiVersion = '\K[^']+" "$VERSION_FILE")
+CURRENT_VERSION=$(sed -n "s/.*apiVersion = '\([^']*\)'.*/\1/p" "$VERSION_FILE")
 IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
 
 case "$BUMP_TYPE" in


### PR DESCRIPTION
BSD grep on macOS does not support `-P`, causing `bin/release.sh` to fail when reading the current `apiVersion` from `src/Http/Client.php`

## Test

Run `sed -n "s/.*apiVersion = '\([^']*\)'.*/\1/p" src/Http/Client.php` locally and confirm it prints the current version

<img width="1016" height="67" alt="image" src="https://github.com/user-attachments/assets/543fb7a7-ac68-4b6c-9de7-eded0dd5f6c3" />
